### PR TITLE
Add a faster C++ Implementation of MIMO WER

### DIFF
--- a/meeteval/wer/matching/cy_mimo_matching.pyx
+++ b/meeteval/wer/matching/cy_mimo_matching.pyx
@@ -7,6 +7,46 @@ cimport cython
 
 ctypedef unsigned int uint
 
+
+cdef extern from "mimo_matching.h":
+    uint levenshtein_distance_(vector[uint] reference, vector[uint] hypothesis)
+    uint mimo_matching_(vector[vector[vector[uint]]] references, vector[vector[uint]] hypotheses)
+
+
+def obj2vec(a, b):
+    int2sym = dict(enumerate(sorted(set(a) | set(b))))
+    sym2int = {v: k for k, v in int2sym.items()}
+    return [sym2int[a_] for a_ in a], [sym2int[b_] for b_ in b]
+
+
+def levenshtein_distance_cpp(
+        reference,
+        hypothesis,
+):
+    reference, hypothesis = obj2vec(reference, hypothesis)
+    print(reference, hypothesis)
+    return levenshtein_distance_(reference, hypothesis)
+
+
+def mimo_matching_cpp(
+        references,
+        hypotheses,
+):
+    all_symbols = set()
+    for r in references:
+        for r_ in r:
+            all_symbols.update(set(list(r_)))
+    for h in hypotheses:
+        all_symbols.update(set(list(h)))
+    int2sym = dict(enumerate(sorted(all_symbols)))
+    sym2int = {v: k for k, v in int2sym.items()}
+
+    references = [[[sym2int[r__] for r__ in r_] for r_ in r] for r in references]
+    hypotheses = [[sym2int[h_] for h_ in h] for h in hypotheses]
+
+    return mimo_matching_(references, hypotheses)
+
+
 cdef uint update_lev_row(uint * row, uint * from_index_buffer, vector[uint] ref, vector[uint] hyp):
     """
     Updates the levenshtein matrix row `row` with symbols from `ref`.

--- a/meeteval/wer/matching/cy_mimo_matching.pyx
+++ b/meeteval/wer/matching/cy_mimo_matching.pyx
@@ -28,7 +28,7 @@ def levenshtein_distance_cpp(
     return levenshtein_distance_(reference, hypothesis)
 
 
-def mimo_matching_cpp(
+def cpp_mimo_matching(
         references,
         hypotheses,
 ):

--- a/meeteval/wer/matching/cy_mimo_matching.pyx
+++ b/meeteval/wer/matching/cy_mimo_matching.pyx
@@ -10,7 +10,7 @@ ctypedef unsigned int uint
 
 cdef extern from "mimo_matching.h":
     uint levenshtein_distance_(vector[uint] reference, vector[uint] hypothesis)
-    uint mimo_matching_(vector[vector[vector[uint]]] references, vector[vector[uint]] hypotheses)
+    pair[uint, vector[pair[uint, uint]]] mimo_matching_(vector[vector[vector[uint]]] references, vector[vector[uint]] hypotheses)
 
 
 def obj2vec(a, b):

--- a/meeteval/wer/matching/mimo_matching.h
+++ b/meeteval/wer/matching/mimo_matching.h
@@ -1,0 +1,156 @@
+#pragma clang diagnostic push
+#pragma ide diagnostic ignored "UnreachableCode"
+#include <vector>
+#include <numeric>
+#include <stdio.h>
+#include <algorithm>
+
+
+void update_levenshtein_row(
+        std::vector<unsigned int> &row,
+        const std::vector<unsigned int> &reference,
+        const std::vector<unsigned int> &hypothesis
+) {
+    // TODO: track where stuff came from
+    // Temporary variables
+    unsigned int up;    // Value above the current cell (deletion)
+    unsigned int diagonal;  // Value diagonal to the current cell (substitution)
+    unsigned int left;
+
+    for (auto ref_symbol: reference) {
+        diagonal = row[0]++;  // diagonal = row[0]; row[0] = row[0] + 1;
+        left = row[0];
+
+        unsigned int hyp_index = 1;
+        for (auto hyp_symbol: hypothesis) {
+            up = row[hyp_index];
+            if (ref_symbol == hyp_symbol) {
+                left = diagonal;
+            } else {
+                left = 1 + std::min(std::min(left, up), diagonal);
+            }
+            row[hyp_index] = left;
+            diagonal = up;
+            hyp_index++;
+        }
+    }
+}
+
+unsigned int levenshtein_distance_(
+        const std::vector<unsigned int> reference,
+        const std::vector<unsigned int> hypothesis
+) {
+    // Temporary memory (one row of the levenshtein matrix)
+    std::vector<unsigned int> row(hypothesis.size() + 1);
+
+    // Initialize with range
+    std::iota(row.begin(), row.end(), 0);
+
+    update_levenshtein_row(row, reference, hypothesis);
+
+    return row[row.size() - 1];
+}
+
+struct Layout {
+    std::vector<unsigned int> strides;
+    std::vector<unsigned int> dimensions;
+    unsigned int total_size;
+};
+
+template<typename T>
+Layout inline make_layout(const std::vector<std::vector<T>> vec) {
+    Layout layout;
+    for (auto v : vec) layout.dimensions.push_back(v.size() + 1);
+    unsigned int j = 1;
+    for (auto i : layout.dimensions) {
+        layout.strides.push_back(j);
+        j *= i;
+    }
+    layout.total_size = j;
+    return layout;
+}
+
+unsigned int mimo_matching_(
+        std::vector<std::vector<std::vector<unsigned int>>> references, std::vector<std::vector<unsigned int>> hypotheses
+) {
+    // Get dimensions and layouts for the storage
+    Layout ref_layout = make_layout(references);
+    Layout hyp_layout = make_layout(hypotheses);
+
+    // Build reference storage grid
+    std::vector<std::vector<unsigned int>> ref_grid(ref_layout.total_size);
+
+    // Initialize first element
+    auto state = std::vector<unsigned int>(hyp_layout.total_size);
+    for (unsigned int i = 0; i < hyp_layout.total_size; i++) {
+        unsigned int j = 0;
+        // TODO: can this be simplified?
+        for (unsigned int v = 0; v < hyp_layout.dimensions.size(); v++) {
+            j += (i / hyp_layout.strides[v]) % hyp_layout.dimensions[v];
+        }
+        state[i] = j;
+    }
+    ref_grid[0] = state;
+
+    std::vector<unsigned int> reference_indices(references.size(), 0);
+
+    // Main loop
+    for (unsigned int reference_utterance_index = 1; reference_utterance_index < ref_layout.total_size; reference_utterance_index++) {
+        // Advance the index by one
+        for (unsigned int i = 0; i < references.size(); i++) {
+            reference_indices[i]++;
+            if (reference_indices[i] < ref_layout.dimensions[i]) break;
+            reference_indices[i] = 0;
+        }
+
+        // Get destination storage
+        auto state = std::vector<unsigned int>(hyp_layout.total_size);
+        auto first_update = true;
+
+        // Loop through all adjacent reference combinations and advance row
+        for (unsigned int active_reference_index = 0; active_reference_index < reference_indices.size(); active_reference_index++) {
+            if (reference_indices[active_reference_index] == 0) continue;
+
+            // Get the previous state, only based on the current assignment of
+            // references
+            std::vector<unsigned int> &previous_state = ref_grid[reference_utterance_index - ref_layout.strides[active_reference_index]];
+            std::vector<unsigned int> &active_reference = references[active_reference_index][reference_indices[active_reference_index] - 1];
+
+            // Forward levenshtein row
+            for (unsigned int active_hypothesis_index = 0; active_hypothesis_index < hypotheses.size(); active_hypothesis_index++) {
+                for (
+                        unsigned int _i = 0;
+                        _i < hyp_layout.total_size;
+                        _i += hyp_layout.strides.size() > active_hypothesis_index + 1 ? hyp_layout.strides[active_hypothesis_index + 1] : hyp_layout.total_size
+                ) {
+                    for (
+                            unsigned int i = _i;
+                            i < _i + hyp_layout.strides[active_hypothesis_index];
+                            i++
+                    ) {
+                        // Copy the levenshtein row into the buffer
+                        std::vector<unsigned int> tmp_row(hyp_layout.dimensions[active_hypothesis_index]);
+                        for (unsigned int j = 0; j < hyp_layout.dimensions[active_hypothesis_index]; j++) {
+                            tmp_row[j] = previous_state[i + j * hyp_layout.strides[active_hypothesis_index]];
+                        }
+
+                        // Apply levenshtein algorithm
+                        update_levenshtein_row(tmp_row, active_reference, hypotheses[active_hypothesis_index]);
+
+                        // Update current state. Keep only the min value. Do inverse of the above stride access
+                        for (unsigned int j = 0; j < hyp_layout.dimensions[active_hypothesis_index]; j++) {
+                            if (first_update || state[i + j * hyp_layout.strides[active_hypothesis_index]] > tmp_row[j]) {
+                                state[i + j*hyp_layout.strides[active_hypothesis_index]] = tmp_row[j];
+                            }
+                        }
+                    }
+                }
+                first_update = false;
+            }
+        }
+        ref_grid[reference_utterance_index] = state;
+    }
+    return ref_grid.back().back();
+}
+
+#pragma clang diagnostic pop

--- a/meeteval/wer/wer/mimo.py
+++ b/meeteval/wer/wer/mimo.py
@@ -43,7 +43,7 @@ def mimo_word_error_rate(
     MimoErrorRate(errors=0, length=6, insertions=0, deletions=0, substitutions=0, error_rate=0.0, assignment=[('A', 'O2'), ('B', 'O2'), ('A', 'O1')])
 
     """
-    from meeteval.wer.matching.mimo_matching import mimo_matching_v3
+    from meeteval.wer.matching.mimo_matching import mimo_matching
 
     def to_list(obj):
         if isinstance(obj, dict):
@@ -68,7 +68,7 @@ def mimo_word_error_rate(
         for ref_chn in reference_values
     ]
     hypothesis_words = [h.split() for h in hypothesis_values]
-    distance, assignment = mimo_matching_v3(reference_words, hypothesis_words)
+    distance, assignment = mimo_matching(reference_words, hypothesis_words)
 
     assignment = [
         (reference_keys[r], hypothesis_keys[h]) for r, h in assignment]

--- a/tests/test_mimo_matching.py
+++ b/tests/test_mimo_matching.py
@@ -85,3 +85,20 @@ def test_against_orc(ref, hyps):
     )
 
 
+@given(ref=reference(2, 2), hyps=hypothesis(3))
+@settings(deadline=None)    # The tests take longer on the GitHub actions test servers
+def test_mimo_v2_against_cpp(ref, hyps):
+    """Test brute-force algorithm against DP algorithm for smaller examples"""
+    from meeteval.wer.matching.cy_mimo_matching import mimo_matching_cpp
+    distance_v2, assignment_v2 = mimo_matching.mimo_matching_v2(ref, hyps)
+    distance_cpp, assignment_cpp = mimo_matching_cpp(ref, hyps)
+
+    assert distance_v2 == distance_cpp
+
+    # We cannot easily check the assignment because there might be multiple
+    # assignments with the same distance. Check that the distance for them is
+    # equal instead
+    assert assignment_v2 == assignment_cpp or (
+            mimo_matching._levensthein_distance_for_assignment(ref, hyps, assignment_v2) ==
+            mimo_matching._levensthein_distance_for_assignment(ref, hyps, assignment_cpp)
+    )

--- a/tests/test_mimo_matching.py
+++ b/tests/test_mimo_matching.py
@@ -3,6 +3,8 @@ import pytest
 from meeteval.wer.matching import orc_matching, mimo_matching
 from hypothesis import given, strategies as st, settings  # pip install hypothesis
 
+from meeteval.wer.wer.mimo import apply_mimo_assignment
+
 # Set up hypothesis strategies
 # Limit alphabet to ensure a few correct matches. Every character represents
 # a word
@@ -25,15 +27,21 @@ def hypothesis(max_channels):
     return st.lists(utterance, min_size=1, max_size=max_channels)
 
 
+def _levensthein_distance_for_assignment(ref, hyps, assignment):
+    import editdistance
+    ref_, hyp_ = apply_mimo_assignment(assignment, ref, hyps)
+    d = sum([editdistance.distance([r__ for r_ in h for r__ in r_], r) for h, r in zip(ref_, hyp_)])
+    return d
+
+
 def _check_output(distance, assignment, ref, hyps):
     assert isinstance(distance, int)
     assert distance >= 0
     assert len(assignment) == sum(len(r) for r in ref)
-    print(assignment)
     assert all(isinstance(a, tuple) for a in assignment)
     assert all(0 <= r < len(ref) for r, h in assignment)
     assert all(0 <= h < len(hyps) for r, h in assignment)
-    d = mimo_matching._levensthein_distance_for_assignment(ref, hyps, assignment)
+    d = _levensthein_distance_for_assignment(ref, hyps, assignment)
     assert d == distance, (d, distance, assignment)
 
 
@@ -54,6 +62,14 @@ def test_mimo_matching_v3_burn(ref, hyps):
     _check_output(distance, assignment, ref, hyps)
 
 
+@given(reference(3, 8), hypothesis(3))
+@settings(deadline=None)    # The tests take longer on the GitHub actions test servers
+def test_mimo_matching_v4_burn(ref, hyps):
+    """Burn-test."""
+    distance, assignment = mimo_matching.mimo_matching_v4(ref, hyps)
+    _check_output(distance, assignment, ref, hyps)
+
+
 @given(ref=reference(2, 2), hyps=hypothesis(3))
 @settings(deadline=None)    # The tests take longer on the GitHub actions test servers
 def test_mimo_v2_against_v3(ref, hyps):
@@ -67,8 +83,8 @@ def test_mimo_v2_against_v3(ref, hyps):
     # assignments with the same distance. Check that the distance for them is
     # equal instead
     assert assignment_v2 == assignment_v3 or (
-            mimo_matching._levensthein_distance_for_assignment(ref, hyps, assignment_v2) ==
-            mimo_matching._levensthein_distance_for_assignment(ref, hyps, assignment_v3)
+            _levensthein_distance_for_assignment(ref, hyps, assignment_v2) ==
+            _levensthein_distance_for_assignment(ref, hyps, assignment_v3)
     )
 
 
@@ -80,25 +96,24 @@ def test_against_orc(ref, hyps):
 
     assert mimo_distance == orc_distance
     assert tuple([x[1] for x in mimo_assignment]) == tuple(orc_assignment) or (
-            mimo_matching._levensthein_distance_for_assignment(ref, hyps, mimo_assignment) ==
+            _levensthein_distance_for_assignment(ref, hyps, mimo_assignment) ==
             orc_matching._levensthein_distance_for_assignment(ref[0], hyps, orc_assignment)
     )
 
 
 @given(ref=reference(2, 2), hyps=hypothesis(3))
 @settings(deadline=None)    # The tests take longer on the GitHub actions test servers
-def test_mimo_v2_against_cpp(ref, hyps):
+def test_mimo_v2_against_v4(ref, hyps):
     """Test brute-force algorithm against DP algorithm for smaller examples"""
-    from meeteval.wer.matching.cy_mimo_matching import mimo_matching_cpp
     distance_v2, assignment_v2 = mimo_matching.mimo_matching_v2(ref, hyps)
-    distance_cpp, assignment_cpp = mimo_matching_cpp(ref, hyps)
+    distance_v4, assignment_v4 = mimo_matching.mimo_matching_v4(ref, hyps)
 
-    assert distance_v2 == distance_cpp
+    assert distance_v2 == distance_v4
 
     # We cannot easily check the assignment because there might be multiple
     # assignments with the same distance. Check that the distance for them is
     # equal instead
-    assert assignment_v2 == assignment_cpp or (
-            mimo_matching._levensthein_distance_for_assignment(ref, hyps, assignment_v2) ==
-            mimo_matching._levensthein_distance_for_assignment(ref, hyps, assignment_cpp)
+    assert assignment_v2 == assignment_v4 or (
+            _levensthein_distance_for_assignment(ref, hyps, assignment_v2) ==
+            _levensthein_distance_for_assignment(ref, hyps, assignment_v4)
     )


### PR DESCRIPTION
The C++ implementation in this PR is easier to read and faster than the Cython implementation. This is due to a few small optimizations getting rid of indexing operations and multiplications. The overall speedup is about 3-6 on the benchmark from the publication. This PR does not change memory usage.