### PR TITLE
Bugfix: Mapping in cpwer was in special cases suboptimal

### DIFF
--- a/meeteval/io/base.py
+++ b/meeteval/io/base.py
@@ -141,7 +141,7 @@ class Base:
                 p.pretty(list(self.lines))
 
     def dump(self, file):
-        with open(file, 'w') as fd:
+        with _open(file, 'w') as fd:
             for line in self.lines:
                 fd.write(line.serialize() + '\n')
 

--- a/meeteval/io/base.py
+++ b/meeteval/io/base.py
@@ -192,7 +192,7 @@ class Base:
     def grouped_by_speaker_id(self):
         return self.groupby(lambda x: x.speaker_id)
 
-    def sorted(self, key=None):
+    def sorted(self, key: 'str | callable | tuple | list' = None):
         """
         This wrapper of sorted.
 
@@ -209,6 +209,13 @@ class Base:
             new = rttm.sorted(key=lambda x: (x.filename, x.begin_time))
 
         """
+        if isinstance(key, str):
+            attribute = key
+            key = lambda x: getattr(x, attribute)
+        elif isinstance(key, (tuple, list)):
+            attributes = key
+            key = lambda x: tuple([getattr(x, a) for a in attributes])
+
         return self.__class__(sorted(self.lines, key=key))
 
     def sorted_by_begin_time(self):

--- a/meeteval/wer/utils.py
+++ b/meeteval/wer/utils.py
@@ -1,13 +1,25 @@
-def _items(obj):
+def _items(obj: 'dict | tuple | list'):
     if isinstance(obj, dict):
-        return obj.items()
+        return list(obj.items())
     elif isinstance(obj, (tuple, list)):
-        return enumerate(obj)
+        return list(enumerate(obj))
     else:
         raise TypeError(type(obj), obj)
 
-def _keys(obj):
+
+def _keys(obj: 'dict | tuple | list'):
     if isinstance(obj, dict):
         return list(obj.keys())
-    else:
+    elif isinstance(obj, (tuple, list)):
         return list(range(len(obj)))
+    else:
+        raise TypeError(type(obj), obj)
+
+
+def _values(obj: 'dict | tuple | list'):
+    if isinstance(obj, dict):
+        return list(obj.values())
+    elif isinstance(obj, (tuple, list)):
+        return obj
+    else:
+        raise TypeError(type(obj), obj)

--- a/meeteval/wer/wer/time_constrained.py
+++ b/meeteval/wer/wer/time_constrained.py
@@ -165,6 +165,7 @@ def time_constrained_minimum_permutation_word_error_rate(
 
     return _cp_word_error_rate(
         reference, hypothesis,
-        distance=lambda tt, et: time_constrained_levenshtein_distance(tt[0], et[0], tt[1], et[1]),
-        siso_error_rate=_time_constrained_siso_error_rate,
+        distance_fn=lambda tt, et: time_constrained_levenshtein_distance(tt[0], et[0], tt[1], et[1]),
+        siso_error_rate=lambda tt, et: _time_constrained_siso_error_rate(tt[0], et[0], tt[1], et[1]),
+        fillvalue=[[], []],
     )

--- a/meeteval/wer/wer/time_constrained.py
+++ b/meeteval/wer/wer/time_constrained.py
@@ -167,5 +167,5 @@ def time_constrained_minimum_permutation_word_error_rate(
         reference, hypothesis,
         distance_fn=lambda tt, et: time_constrained_levenshtein_distance(tt[0], et[0], tt[1], et[1]),
         siso_error_rate=lambda tt, et: _time_constrained_siso_error_rate(tt[0], et[0], tt[1], et[1]),
-        fillvalue=[[], []],
+        missing=[[], []],
     )

--- a/meeteval/wer/wer/time_constrained.py
+++ b/meeteval/wer/wer/time_constrained.py
@@ -15,8 +15,8 @@ if typing.TYPE_CHECKING:
 
     class Segment(TypedDict):
         words: str
-        start_time: int | float
-        end_time: int | float
+        start_time: 'int | float'
+        end_time: 'int | float'
 
 
 __all__ = ['time_constrained_minimum_permutation_word_error_rate', 'time_constrained_siso_word_error_rate']
@@ -80,7 +80,7 @@ def _get_words_and_intervals(segments: 'List[Segment]', pseudo_word_level_strate
 def _map(fn, x):
     if isinstance(x, dict):
         return {k: fn(v) for k, v in x.items()}
-    elif isinstance(x, (list, dict)):
+    elif isinstance(x, (list, tuple)):
         return [fn(v) for v in x]
     else:
         raise TypeError()
@@ -149,10 +149,8 @@ def time_constrained_minimum_permutation_word_error_rate(
         reference_collar: int = 0,
         hypothesis_collar: int = 0,
 ) -> CPErrorRate:
-    import numpy as np
     from meeteval.wer.matching.cy_levenshtein import time_constrained_levenshtein_distance
-    import scipy.optimize
-    import itertools
+    from meeteval.wer.wer.cp import _cp_word_error_rate
 
     for k, v in _items(reference):
         _check_timing_annotations([(s['start_time'], s['end_time']) for s in v], f'reference {k}')
@@ -165,88 +163,8 @@ def time_constrained_minimum_permutation_word_error_rate(
     hypothesis = _map(lambda x: _get_words_and_intervals(x, hypothesis_pseudo_word_level_timing, hypothesis_collar),
                       hypothesis)
 
-    if isinstance(hypothesis, dict):
-        hypothesis_keys = list(hypothesis.keys())
-        hypothesis_values = list(hypothesis.values())
-    else:
-        hypothesis_keys = list(range(len(hypothesis)))
-        hypothesis_values = hypothesis
-    if isinstance(reference, dict):
-        reference_keys = list(reference.keys())
-        reference_values = list(reference.values())
-    else:
-        reference_keys = list(range(len(reference)))
-        reference_values = reference
-
-
-
-    cost_matrix = np.array([
-        [
-            time_constrained_levenshtein_distance(tt[0], et[0], tt[1], et[1])
-            for et in hypothesis_values
-        ]
-        for tt in reference_values
-    ])
-
-    # Find the best permutation with hungarian algorithm
-    row_ind, col_ind = scipy.optimize.linear_sum_assignment(cost_matrix)
-    distances = cost_matrix[row_ind, col_ind]
-    distances = list(distances)
-
-    # Handle over-/under-estimation
-    if len(hypothesis_values) > len(reference_values):
-        # Over-estimation: Add full length of over-estimated hypotheses
-        # to distance
-        none_assigned = sorted(set(range(len(hypothesis_values))) - set(col_ind))
-        for i in none_assigned:
-            distances.append(len(hypothesis_values[i][0]))
-        col_ind = [*col_ind, *none_assigned]
-    elif len(hypothesis_values) < len(reference_values):
-        # Under-estimation: Add full length of the unused references
-        none_assigned = sorted(set(range(len(reference_values))) - set(row_ind))
-        for i in none_assigned:
-            distances.append(len(reference_values[i][0]))
-        row_ind = [*row_ind, *none_assigned]
-
-    # Compute WER from distance
-    distance = sum(distances)
-
-    assignment = tuple([
-        (
-            reference_keys[r] if r is not None else r,
-            hypothesis_keys[c] if c is not None else c,
-        )
-        for r, c in itertools.zip_longest(row_ind, col_ind)
-    ])
-
-    missed_speaker = max(0, len(reference) - len(hypothesis))
-    falarm_speaker = max(0, len(hypothesis) - len(reference))
-
-    from meeteval.wer.wer.cp import apply_cp_assignment
-    reference_new, hypothesis_new = apply_cp_assignment(
-        assignment,
-        reference=reference,
-        hypothesis=hypothesis,
-        missing=([], []),
-    )
-
-    er = sum([
-        _time_constrained_siso_error_rate(
-            r[0], hypothesis_new[speaker][0],
-            r[1], hypothesis_new[speaker][1],
-        )
-        for speaker, r in _items(reference_new)
-    ])
-    assert distance == er.errors, (distance, er)
-    assert distance == er.errors, (distance, er)
-
-    return CPErrorRate(
-        er.errors, er.length,
-        insertions=er.insertions,
-        deletions=er.deletions,
-        substitutions=er.substitutions,
-        missed_speaker=missed_speaker,
-        falarm_speaker=falarm_speaker,
-        scored_speaker=len(reference),
-        assignment=assignment,
+    return _cp_word_error_rate(
+        reference, hypothesis,
+        distance=lambda tt, et: time_constrained_levenshtein_distance(tt[0], et[0], tt[1], et[1]),
+        siso_error_rate=_time_constrained_siso_error_rate,
     )

--- a/tests/test_time_constrained.py
+++ b/tests/test_time_constrained.py
@@ -101,3 +101,33 @@ def test_time_constrained_levenshtein_distance_with_alignment_against_kaldialign
     assert kaldialign_statistics['sub'] == statistics['substitutions'], (kaldialign_statistics, statistics)
     assert kaldialign_statistics['total'] == statistics['total'], (kaldialign_statistics, statistics)
     assert kaldialign_statistics['del'] == statistics['deletions'], (kaldialign_statistics, statistics)
+
+
+@given(
+    st.composite(lambda draw: [
+        [
+            draw(st.text(alphabet='abcdefg', min_size=1, max_size=3))
+            for _ in range(draw(st.integers(min_value=2, max_value=10)))
+        ]
+        for _ in range(draw(st.integers(min_value=2, max_value=10)))
+    ])(),
+    st.composite(lambda draw: [
+        [
+            draw(st.text(alphabet='abcdefg', min_size=1, max_size=3))
+            for _ in range(draw(st.integers(min_value=2, max_value=10)))
+        ]
+        for _ in range(draw(st.integers(min_value=2, max_value=10)))
+    ])(),
+)
+def test_tcpwer_vs_cpwer(
+        a, b
+):
+    from meeteval.wer.wer.time_constrained import time_constrained_minimum_permutation_word_error_rate
+    from meeteval.wer.wer.cp import cp_word_error_rate
+
+    cp_statistics = cp_word_error_rate([' '.join(speaker) for speaker in a], [' '.join(speaker) for speaker in b])
+    tcp_statistics = time_constrained_minimum_permutation_word_error_rate(
+        [[{'words': word, 'start_time': 0, 'end_time': 1} for word in speaker] for speaker in a],
+        [[{'words': word, 'start_time': 0, 'end_time': 1} for word in speaker] for speaker in b],
+    )
+    assert cp_statistics == tcp_statistics, (cp_statistics, tcp_statistics)


### PR DESCRIPTION
Those hyp/ref, that got no ref/hyp assigned where ignored in the
estimation of the best mapping. Hence, it could happen (typically with
bad transcriptions), that the estimated mapping is not the best mapping.
Now the full cost_matrix is estimated and for over- and underestimation,
the mapping is also correct, when the transcriptions are bad.

Thanks to @popcornell for finding this bug.