### PR TITLE
Remove editdistance dependency

### DIFF
--- a/meeteval/wer/matching/orc_matching.py
+++ b/meeteval/wer/matching/orc_matching.py
@@ -31,18 +31,18 @@ def _get_channel_transcription_from_assignment(
 
 
 def _levensthein_distance_for_assignment(ref, hyps, assignment):
-    import editdistance
+    from meeteval.wer.matching.cy_levenshtein import levenshtein_distance
     c = _get_channel_transcription_from_assignment(
         ref, assignment, num_channels=len(hyps)
     )
-    d = sum([editdistance.distance(h, r) for h, r in zip(hyps, c)])
+    d = sum([levenshtein_distance(h, r) for h, r in zip(hyps, c)])
     return d
 
 
 def orc_matching_v1(ref, hyps):
     """
     Version 1 is a brute-force implementation of the orc levenshtein distance
-    in Python using the fast editdistance package.
+    in Python using a fast implementation of the Levenshtein distance.
     """
     import itertools
     num_channels = len(hyps)
@@ -173,7 +173,4 @@ def orc_matching_v3(
 
     distance, assignemnt = cy_orc_matching(ref, hyps)
 
-    # TODO: have a "self-test" here against editdistance?
-    # d = _levensthein_distance_for_assignemnt(ref, hyps, assignment)
-    # assert d == distance, (d, distance, assignment)
     return distance, assignemnt

--- a/meeteval/wer/wer/cp.py
+++ b/meeteval/wer/wer/cp.py
@@ -124,8 +124,7 @@ def cp_word_error_rate(
     >>> cp_word_error_rate({'r0': 'a b'}, {'h0': 'z', 'h1': 'a e f'})  # Special case for overestimation, that was buggy in the past.
     CPErrorRate(errors=3, length=2, insertions=2, deletions=0, substitutions=1, error_rate=1.5, missed_speaker=0, falarm_speaker=1, scored_speaker=1, assignment=(('r0', 'h1'), (None, 'h0')))
     """
-    import editdistance
-
+    from meeteval.wer.matching.cy_levenshtein import levenshtein_distance
     def transcription_to_words(x):
         if isinstance(x, dict):
             return {k: v.split() for k, v in x.items()}
@@ -139,7 +138,7 @@ def cp_word_error_rate(
     return _cp_word_error_rate(
         transcription_to_words(reference),
         transcription_to_words(hypothesis),
-        distance_fn=editdistance.distance,
+        distance_fn=levenshtein_distance,
         siso_error_rate=_siso_error_rate,
     )
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ setup(
     ext_modules=ext_modules,
     packages=["meeteval"],
     install_requires=[
-        'editdistance',
         'kaldialign',
         'scipy',  # scipy.optimize.linear_sum_assignment
         "typing_extensions; python_version<'3.8'",  # Missing Literal in py37
@@ -28,6 +27,7 @@ setup(
             'pyyaml',
         ],
         'test': [
+            'editdistance',     # Faulty for long sequences, but useful for testing
             'pytest',
             'hypothesis',
             'click',

--- a/tests/test_levenshtein.py
+++ b/tests/test_levenshtein.py
@@ -1,4 +1,5 @@
 from hypothesis import given, strategies as st
+from meeteval.wer.matching.cy_levenshtein import levenshtein_distance
 
 # Limit alphabet to ensure a few correct matches
 string = st.text(alphabet='abcdefg', min_size=0, max_size=100)
@@ -8,7 +9,6 @@ string = st.text(alphabet='abcdefg', min_size=0, max_size=100)
 def test_against_editdistance(a, b):
     """Test against the well-known `editdistance` package"""
     import editdistance
-    from meeteval.wer.matching.cy_levenshtein import levenshtein_distance
 
     ref_distance = editdistance.distance(a, b)
     distance = levenshtein_distance(a, b)
@@ -18,8 +18,6 @@ def test_against_editdistance(a, b):
 
 @given(string, string)
 def test_custom_cost_against_levenshtein_default(a, b):
-    from meeteval.wer.matching.cy_levenshtein import levenshtein_distance
-
     assert levenshtein_distance(a, b, 1, 1, 1, 0) == levenshtein_distance(a, b)
     assert levenshtein_distance(a, b, 2, 2, 2, 0) == 2 * levenshtein_distance(a, b)
 
@@ -29,8 +27,6 @@ def test_custom_cost(a, b):
     """
     Test a few weird special configurations
     """
-    from meeteval.wer.matching.cy_levenshtein import levenshtein_distance
-
     assert levenshtein_distance(a, b, 0, 0, 0, 0) == 0
     assert levenshtein_distance(a, b, 1, 1, 0, 0) == max(len(a), len(b)) - min(len(a), len(b))
 


### PR DESCRIPTION
editdistance produces wrong results for long sequences (https://github.com/roy-ht/editdistance/pull/103) and the maintainer doesn't seem to be active. Use our impelmentation of the Levenshtein distance instead