### PR TITLE
build: add `build-system` via `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "Cython"]


### PR DESCRIPTION
## Changes

Allows the project to be built w/o the manual installation of `cython`.


