### PR TITLE
Add workflow file for PyPI sdist release

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,6 @@
+[bumpversion]
+current_version = 0.0.0
+commit = True
+tag = True
+
+[bumpversion:file:setup.py]

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -1,0 +1,31 @@
+name: Publish Python 🐍 distributions 📦 to PyPI
+
+# Run when a new release is created on GitHub
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+    steps:
+      # retrieve your distributions here
+      - uses: actions/checkout@master
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: >-
+            python -m pip install build --user
+      - name: Build
+        run: >-
+            python -m build --sdist --outdir dist/ .
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,9 @@ name: Publish Python 🐍 distributions 📦 to PyPI
 
 # Run when a new release is created on GitHub
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   release:

--- a/maintenance.md
+++ b/maintenance.md
@@ -1,0 +1,12 @@
+# Publish Release
+
+Tag and push to GitHub:
+```shell
+git clone github.com:meeteval/meeteval.git
+cd meteval
+pip install --upgrade bump2version
+bump2version --verbose --tag patch  # major, minor or patch
+git push origin --tags
+```
+
+This will trigger a GitHub Action that will build and publish the package to PyPI.

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
         'Cython'
     ],
     extras_require=extras_require,
+    package_data={'meeteval': ['**/*.pyx', '**/*.h']},  # https://stackoverflow.com/a/60751886
     entry_points={
         'console_scripts': [
             'meeteval-wer=meeteval.wer.__main__:cli'

--- a/setup.py
+++ b/setup.py
@@ -50,9 +50,7 @@ extras_require['all'] = list(dict.fromkeys(sum(extras_require.values(), [])))
 setup(
     name="meeteval",
 
-    # Versions should comply with PEP440.  For a discussion on single-sourcing
-    # the version across setup.py and the project code, see
-    # https://packaging.python.org/en/latest/single_source_version.html
+    # Versions should comply with PEP440.
     version='0.0.0',
 
     python_requires=">=3.5",

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from distutils.extension import Extension
+from pathlib import Path
 
 from setuptools import setup, find_packages
 
@@ -47,14 +48,58 @@ extras_require = {
 }
 extras_require['all'] = list(dict.fromkeys(sum(extras_require.values(), [])))
 
+# Get the long description from the relevant file
+try:
+    from os import path
+
+    here = path.abspath(path.dirname(__file__))
+    with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+        long_description = f.read()
+except FileNotFoundError:
+    long_description = ''
+
 setup(
     name="meeteval",
 
     # Versions should comply with PEP440.
     version='0.0.0',
 
+    # The project's main homepage.
+    url='https://github.com/fgnt/meeteval/',
+
+    # Choose your license
+    license='MIT',
+
+    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
+    classifiers=[
+        # How mature is this project? Common values are
+        #   3 - Alpha
+        #   4 - Beta
+        #   5 - Production/Stable
+        'Development Status :: 5 - Production/Stable',
+
+        # Indicate who your project is intended for
+        'Intended Audience :: Science/Research',
+
+        # Pick your license as you wish (should match "license" above)
+        'License :: OSI Approved :: MIT License',
+
+        # Specify the Python versions you support here. In particular, ensure
+        # that you indicate whether you support Python 2, Python 3 or both.
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+    ],
+
     python_requires=">=3.5",
-    author="Thilo von Neumann",
+    author="Department of Communications Engineering, Paderborn University",
+    author_email='sek@nt.upb.de',
+    keywords='speech recognition, word error rate, evaluation, meeting, ASR, WER',
+    long_description=long_description,
+    long_description_content_type='text/markdown',  # Optional (see note above)
+
     ext_modules=ext_modules,
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,12 @@ extras_require['all'] = list(dict.fromkeys(sum(extras_require.values(), [])))
 
 setup(
     name="meeteval",
+
+    # Versions should comply with PEP440.  For a discussion on single-sourcing
+    # the version across setup.py and the project code, see
+    # https://packaging.python.org/en/latest/single_source_version.html
+    version='0.0.0',
+
     python_requires=">=3.5",
     author="Thilo von Neumann",
     ext_modules=ext_modules,


### PR DESCRIPTION
Add a GitHub workflow for publishing on PyPI. The workflow gets executed when a release is created on GitHub.

Currently, only sdist is built since building wheels for a Cython package is tricky.

The workflow uses a "truested publisher" (https://docs.pypi.org/trusted-publishers/using-a-publisher/) to push the release to PyPI. This way, no credentials are stored in the GitHub repository.