### PR TITLE
Add first version of time-constrained ORC-WER (tcORC-WER)

### DIFF
--- a/meeteval/wer/__main__.py
+++ b/meeteval/wer/__main__.py
@@ -320,6 +320,29 @@ def tcpwer(
     average.reference_self_overlap.warn('reference')
 
 
+def tcorcwer(
+        reference, hypothesis,
+        average_out='{parent}/{stem}_tcorcwer.json',
+        per_reco_out='{parent}/{stem}_tcorcwer_per_reco.json',
+        regex=None,
+        collar=0,
+        hyp_pseudo_word_timing='character_based_points',
+        ref_pseudo_word_timing='character_based',
+        hypothesis_sort='segment',
+):
+    """Computes the time-constrained ORC WER (tcORC WER)"""
+    from meeteval.wer.wer.time_constrained_orc import time_constrained_orc_wer_multifile
+    reference, _, hypothesis, hypothesis_paths = _load_texts(
+        reference, hypothesis, regex)
+    results = time_constrained_orc_wer_multifile(
+        reference, hypothesis, collar=collar,
+        hypothesis_pseudo_word_level_timing=hyp_pseudo_word_timing,
+        reference_pseudo_word_level_timing=ref_pseudo_word_timing,
+        hypothesis_sort=hypothesis_sort,
+    )
+    _save_results(results, hypothesis_paths, per_reco_out, average_out)
+
+
 def _merge(
         files: 'list[str]',
         out: str = None,
@@ -613,6 +636,7 @@ def cli():
     cli.add_command(orcwer)
     cli.add_command(mimower)
     cli.add_command(tcpwer)
+    cli.add_command(tcorcwer)
     cli.add_command(merge)
     cli.add_command(average)
 

--- a/meeteval/wer/matching/cy_time_constrained_orc_matching.pyx
+++ b/meeteval/wer/matching/cy_time_constrained_orc_matching.pyx
@@ -1,0 +1,53 @@
+# distutils: language = c++
+#cython: language_level=3
+
+from libcpp.vector cimport vector
+from libcpp.pair cimport pair
+
+ctypedef unsigned int uint
+
+
+cdef extern from "time_constrained_orc_matching.h":
+    pair[uint, vector[pair[uint, uint]]] time_constrained_orc_levenshtein_distance_(
+            vector[vector[uint]] reference,
+            vector[vector[uint]] hypothesis,
+            vector[vector[pair[double, double]]] reference_timings,
+            vector[vector[pair[double, double]]] hypothesis_timings
+    ) except +
+
+def time_constrained_orc_levenshtein_distance(
+        reference,  # List (utterances) of list of symbols
+        hypothesis, # List (streams) of list of symbols
+        reference_timings,
+        hypothesis_timings
+):
+    # Validate inputs
+    if len(reference) != len(reference_timings):
+        raise ValueError("reference and reference_timings must have the same length")
+    if len(hypothesis) != len(hypothesis_timings):
+        raise ValueError("hypothesis and hypothesis_timings must have the same length")
+
+    # Shortcuts for trivial cases
+    if len(reference) == 0:
+        return sum(len(h) for h in hypothesis), []
+    if len(hypothesis) == 0:
+        return sum(len(r) for r in reference), []
+
+    # Translate symbols/words to integers for the cpp code
+    all_symbols = set()
+    for r in reference:
+        all_symbols.update(set(list(r)))
+    for h in hypothesis:
+        all_symbols.update(set(list(h)))
+    int2sym = dict(enumerate(sorted(all_symbols)))
+    sym2int = {v: k for k, v in int2sym.items()}
+
+    reference = [[sym2int[h_] for h_ in h] for h in reference]
+    hypothesis = [[sym2int[h_] for h_ in h] for h in hypothesis]
+
+    return time_constrained_orc_levenshtein_distance_(
+        reference,
+        hypothesis,
+        reference_timings,
+        hypothesis_timings
+    )

--- a/meeteval/wer/matching/time_constrained_orc_matching.h
+++ b/meeteval/wer/matching/time_constrained_orc_matching.h
@@ -1,0 +1,605 @@
+#include <vector>
+#include <numeric>
+#include <stdio.h>
+#include <algorithm>
+#include <unordered_map>
+#include <map>
+#include <memory>
+#include <cassert>
+#include <stdexcept>
+#include <limits>
+
+//#define at(x) operator[](x)
+
+/*
+ * Get the "next" index. The next index is one that is one where exactly one index is larger than the current index.
+ * If the index is already the last index, it is reset to the first index.
+ * Returns true if the index was advanced, false if it was reset
+ */
+bool advance_index(
+    std::vector<unsigned int> & index,
+    const std::vector<unsigned int> & dimensions,
+    const unsigned int ignore_index=-1
+) {
+    assert(index.size() == dimensions.size());
+    for (std::vector<unsigned int>::size_type d = 0; d < dimensions.size(); d++) {
+        assert(index.at(d) < dimensions.at(d));
+        if (d == ignore_index) continue;
+        if (index.at(d) == dimensions.at(d) - 1) {
+            index.at(d) = 0;
+        } else {
+            index.at(d)++;
+            return true;
+        }
+    }
+    return false;
+}
+
+/*
+ * Represents a memory layout of a tensor when stored flattened in a vector.
+ *
+ * get_index() returns the (integer) index of a given (vector) index in the flattened vector.
+ * advance_index() advances the index to the next index according to the dimensions of this layout. Returns true if
+ *  the index was advanced, false if it was reset
+ * within() checks if the given index is within the dimensions of this layout
+ */
+struct Layout {
+    std::vector<unsigned int> strides;
+    std::vector<unsigned int> dimensions;
+    size_t total_size;
+
+    unsigned int get_index(const std::vector<unsigned int> & index) const {
+        assert(index.size() == dimensions.size());
+        size_t i = 0;
+        for (size_t d = 0; d < dimensions.size(); d++) {
+            assert(index.at(d) < dimensions.at(d));
+            i += index.at(d) * strides.at(d);
+        }
+        return i;
+    }
+
+    bool advance_index(std::vector<unsigned int> & index, const unsigned int ignore_index=-1) const {
+        return ::advance_index(index, dimensions, ignore_index);
+    }
+
+    bool within(const std::vector<unsigned int> & index) const {
+        assert(index.size() == dimensions.size());
+        for (size_t d = 0; d < dimensions.size(); d++) {
+            if (index.at(d) >= dimensions.at(d)) return false;
+        }
+        return true;
+    }
+};
+
+/*
+ * Represents a path through the reference state space
+ */
+struct Path {
+    std::shared_ptr<Path> previous;
+    unsigned int speaker;
+    unsigned int utterance;
+    unsigned int stream;
+};
+
+/*
+ * One entry in the hypothesis state space
+ *
+ * cost: The cost of the path to this state
+ * path: The path (in the reference space) to this state
+ */
+struct HypStateEntry {
+    std::shared_ptr<Path> path;
+    unsigned int cost;
+
+    /*
+     * Returns a new HypStateEntry with the cost incremented by the given value
+     */
+    HypStateEntry incremented_by(const unsigned int increment) const {
+        return HypStateEntry{path, cost + increment};
+    }
+};
+
+/*
+ * Represents an entry state in the reference space
+ *
+ * cost: The cost (in the hypothesis space) of the best path to this state for that hypothesis
+ * layout: The layout of `cost` in the hypothesis space
+ * offset: The offset of `cost` in the hypothesis space
+ */
+struct StateEntry {
+    std::vector<HypStateEntry> cost;
+    Layout layout;
+    std::vector<unsigned int> offset;
+};
+
+/*
+ * Creates a `Layout` from a begin pointer and an end pointer.
+ */
+Layout inline make_layout(
+    const std::vector<unsigned int> begin_pointer,
+    const std::vector<unsigned int> end_pointer
+) {
+    Layout layout;
+    for (size_t d = 0; d < begin_pointer.size(); d++) {
+        layout.dimensions.push_back(end_pointer[d] - begin_pointer[d] + 1);
+    }
+    size_t j = 1;
+    for (auto i : layout.dimensions) {
+        layout.strides.push_back(j);
+
+        // Check for overflow before multiplying
+        if (j * i / i  != j) throw std::overflow_error("overflow_error");
+        j *= i;
+    }
+    layout.total_size = j;
+    return layout;
+}
+
+/*
+ * Represents one reference utterance
+ *
+ * begin_time: The begin time of the utterance (earliest begin time of all words)
+ * end_time: The end time of the utterance (latest end time of all words)
+ * timings: The timings of all words in the utterance
+ * words: The words in the utterance: TODO: is this used?
+ */
+struct Utterance {
+    double begin_time;
+    double end_time;
+//    std::vector<std::pair<double, double>> timings;
+//    std::vector<unsigned int> words;
+};
+
+/*
+ * Bundles all timing information needed for one word
+ *
+ * TODO: rename members?
+ */
+struct Timing {
+    double begin_time;
+    double end_time;
+    double latest_begin_time;
+    double earliest_end_time;
+};
+
+bool overlaps(const Timing & a, const Timing & b) {
+    return a.begin_time < b.end_time && b.begin_time < a.end_time;
+}
+
+bool overlaps2(const Timing & a, const Timing & b) {
+    return a.latest_begin_time < b.earliest_end_time && b.latest_begin_time < a.earliest_end_time;
+}
+
+/*
+ * Creates a std::vector<Timing> from a std::vector<std::pair<double, double>>. Copies the timings
+ * into the struct and fills the latest_begin_time and earliest_end_time fields.
+ */
+std::vector<Timing> make_extended_timing(const std::vector<std::pair<double, double>> & timings) {
+    std::vector<Timing> extended_timings(timings.size());
+    if (timings.size() == 0) return extended_timings;
+
+    double end_time = 0;
+    for (size_t i = 0; i < timings.size(); i++) {
+        end_time = std::max(end_time, timings.at(i).second);
+        extended_timings.at(i) = {
+            .begin_time=timings.at(i).first,
+            .end_time=timings.at(i).second,
+            // latest_begin_time is filled below
+            .earliest_end_time=end_time,
+        };
+    }
+
+    double begin_time = end_time;
+    for (size_t i = timings.size() - 1;; --i) {
+        begin_time = std::min(begin_time, timings.at(i).first);
+        extended_timings.at(i).latest_begin_time = begin_time;
+        if (i == 0) break;
+    }
+    return extended_timings;
+}
+
+struct UpdateState {
+    unsigned int cost;
+    unsigned int index;
+};
+
+/*
+ * Computes a time-constrained update of a levenshtein row, in-place.
+ *
+ * TODO: do we copy too much (up, left, diagonal, ...)?
+ */
+void update_levenshtein_row(
+    std::vector<UpdateState> &row,
+    const std::vector<unsigned int> & reference,
+    const std::vector<unsigned int> & hypothesis,
+    const std::vector<Timing> & reference_timings,
+    const std::vector<Timing> & hypothesis_timings,
+    const unsigned int hypothesis_begin,
+    const unsigned int hypothesis_end
+) {
+    assert(row.size() >= hypothesis_end - hypothesis_begin + 1);
+    assert(reference.size() == reference_timings.size());
+    assert(hypothesis.size() == hypothesis_timings.size());
+    assert(hypothesis_end <= hypothesis.size());
+    assert(hypothesis_begin <= hypothesis_end);
+
+    unsigned int steps = hypothesis_end - hypothesis_begin;
+
+    // These two variables track the currently "active" region in the hypothesis
+    // Any word before hyp_start and after hyp_end will be ignored (as not overlapping)
+    // hyp_start and hyp_end are updated in every iteration
+    unsigned int hyp_start = 0;
+    unsigned int hyp_end = 0;
+
+    for (size_t reference_index = 0; reference_index < reference.size(); reference_index++) {
+//        printf("reference_index %d\n", reference_index);
+        auto ref_symbol = reference.at(reference_index);
+        auto & ref_timing = reference_timings.at(reference_index);
+
+        UpdateState diagonal = row[hyp_start];
+        row[hyp_start].cost++;
+        UpdateState left = row[hyp_start];
+
+        unsigned int row_index = hyp_start + 1;
+        bool allow_shift = true;
+        for (; row_index < steps + 1; row_index++ ) {
+            auto hyp_symbol = hypothesis.at(row_index + hypothesis_begin - 1);
+            auto & hyp_timing = hypothesis_timings.at(row_index + hypothesis_begin - 1);
+            if (allow_shift) {
+                if (ref_timing.latest_begin_time > hyp_timing.earliest_end_time){
+                    // We can shift the starting point forward because nothing will overlap with anything before hyp_start
+                    hyp_start++;
+                } else {
+                    allow_shift = false;
+                }
+            }
+
+            UpdateState up = row[row_index];
+            if (row_index > hyp_end) {
+                up.cost += reference_index;
+                if (diagonal.cost < up.cost) {
+                    up = diagonal;
+                    up.cost++;
+                }
+            }
+
+            if (hyp_timing.begin_time >= ref_timing.end_time || ref_timing.begin_time >= hyp_timing.end_time) {
+                // no overlap. No substitution/correct allowed
+                if (up.cost < left.cost) left = up;
+                left.cost++;
+            } else if (ref_symbol == hyp_symbol) {
+                // Overlap & correct: Diagonal is always the best path
+                left = diagonal;
+            } else {
+                // Overlap & incorrect: Find the best path
+                if (up.cost < left.cost) {
+                    left = up;
+                }
+                if (diagonal.cost < left.cost) {
+                    left = diagonal;
+                }
+                left.cost++; // Cost for ins/del/sub = 1
+            }
+
+            row[row_index] = left;
+            diagonal = up;
+
+            if (allow_shift) {
+                // The final value for the cell at hyp_start can only be reached by insertions (direct path down)
+                // from the current row. So, we can compute the final value by adding the number of updates
+                // that come after this
+                row[row_index - 1].cost += reference.size() - reference_index - 1;
+            }
+            if (ref_timing.earliest_end_time < hyp_timing.latest_begin_time) {
+                break;
+            }
+        }
+        hyp_end = row_index;
+    }
+
+    for (; hyp_end < steps; hyp_end++) {
+        // Get update from top: Initial value + reference.size() insertions
+        UpdateState up = row[hyp_end + 1];
+        up.cost += reference.size();
+
+        // Get update from left: left value + 1 deletion
+        UpdateState left = row[hyp_end];
+        left.cost++;
+
+        if (up.cost < left.cost) left = up;
+        row[hyp_end + 1] = left;
+    }
+}
+
+
+/**
+ * Make utterances from timings.
+ * utterance.begin_time is filled with the earliest begin time of all words in this
+ * utterance and all following utterances.
+ * utterance.end_time is filled with the latest end time of all words in this
+ * utterance and all previous utterances.
+ */
+std::vector<Utterance> make_utterances(std::vector<std::vector<std::pair<double, double>>> & timings) {
+    double end_time = 0;
+    std::vector<Utterance> utterances(timings.size());
+    if (timings.size() == 0) return utterances;
+
+    for (size_t i = 0; i < timings.size(); i++) {
+        // Handle case where words are not sorted by time
+         double begin = std::min_element(
+            timings[i].begin(),
+            timings[i].end(),
+            [](const std::pair<double, double> & a, const std::pair<double, double> & b) {
+                return a.first < b.first;
+            }
+        )->first;
+        end_time = std::max(std::max_element(
+            timings[i].begin(),
+            timings[i].end(),
+            [](const std::pair<double, double> & a, const std::pair<double, double> & b) {
+                return a.second < b.second;
+            })->second, end_time
+        );
+        utterances[i] = {
+            .begin_time=begin,
+            .end_time=end_time,
+//            .timings=timings[i],
+//            .words=reference[d][i],
+        };
+    }
+
+    double begin_time = end_time;
+    for (size_t i = utterances.size() - 1;; --i) {
+        begin_time = std::min(begin_time, utterances[i].begin_time);
+        utterances[i].begin_time = begin_time;
+        if (i == 0) break;
+    }
+    assert(utterances.size() == timings.size());
+    return utterances;
+}
+
+
+/*
+ * TODO: Utterances must be sorted for this algorithm to work!
+ * TODO: All utterances must contain at least one word!
+ * TODO: Must have at least one speaker and one stream!
+ */
+std::pair<unsigned int, std::vector<std::pair<unsigned int, unsigned int>>> time_constrained_orc_levenshtein_distance_(
+    std::vector<std::vector<unsigned int>> reference,
+    std::vector<std::vector<unsigned int>> hypothesis,
+    std::vector<std::vector<std::pair<double, double>>> reference_timings,
+    std::vector<std::vector<std::pair<double, double>>> hypothesis_timings
+) {
+    // Check inputs
+    assert(reference.size() == reference_timings.size());
+    assert(hypothesis.size() == hypothesis_timings.size());
+    for (unsigned int i = 0; i < reference.size(); i++) assert(reference[i].size() == reference_timings[i].size());
+    for (unsigned int i = 0; i < hypothesis.size(); i++) assert(hypothesis[i].size() == hypothesis_timings[i].size());
+    size_t num_reference_speakers = reference.size();
+    size_t num_hypothesis_streams = hypothesis.size();
+    unsigned int num_utterances = reference.size();
+
+    // Convert reference utterances into `Utterance` structs
+    // Track as begin and end time not the actual begin and end time, but the earliest seen end time
+    // and (in reverse) the latest seen begin time to support unsorted utterance begin/end times
+    std::vector<Utterance> reference_utterances = make_utterances(reference_timings);
+
+//    printf("utterances\n");
+//    for (std::vector<Utterance> s : reference_utterances) {
+//        printf("  "); for (Utterance u : s) printf(" (%.2f, %.2f)", u.begin_time, u.end_time); printf("\n");
+//    }
+
+    // Compute for every word in the hypothesis the earliest seen end time and the latest seen begin time
+    // This is required when the words are not sorted by begin time.
+//    printf("computing extended_hypothesis_timings\n");
+    std::vector<std::vector<Timing>> extended_hypothesis_timings(num_hypothesis_streams);
+    for (size_t s = 0; s < hypothesis.size(); s++) {
+//        printf("s: %d, size: %d\n", s, hypothesis_timings.at(s).size());
+        extended_hypothesis_timings.at(s) = make_extended_timing(hypothesis_timings.at(s));
+    }
+
+//    printf("computing extended_reference_timings\n");
+    std::vector<std::vector<Timing>> extended_reference_timings(reference_timings.size());
+    for (size_t u = 0; u < reference_timings.size(); u++) {
+        extended_reference_timings.at(u) = make_extended_timing(reference_timings.at(u));
+    }
+
+    // State: We only need one state here because we only have a single speaker,
+    // i.e., only a single possible path through the reference space
+    StateEntry state = {
+        .cost=std::vector<HypStateEntry>(1),
+        .layout=make_layout(std::vector<unsigned int>(num_hypothesis_streams), std::vector<unsigned int>(num_hypothesis_streams)),
+        .offset=std::vector<unsigned int>(hypothesis.size())
+    };
+    double ref_block_begin_time = 0;
+    double ref_block_end_time = 0;
+
+    // Hypothesis state space indices
+    std::vector<unsigned int> new_state_offset(hypothesis.size());
+    std::vector<unsigned int> new_state_end(hypothesis.size());
+    std::vector<unsigned int> indices;
+
+    // Pre-allocate temporary memory TODO: this is often (but not always!) larger than necessary
+    unsigned int max_num_states = 0;
+    for (size_t s = 0; s < hypothesis.size(); s++) max_num_states = std::max(max_num_states, (unsigned int) hypothesis.at(s).size());
+    std::vector<UpdateState> tmp_row(max_num_states + 1);
+
+    // Iterate through reference utterances in temporal order
+    for (unsigned int u = 0; u < num_utterances; u++) {
+        Utterance current_reference_utterance = reference_utterances.at(u);
+
+        // Compute size of new state TODO: is this too large?
+        // This state has the dimensions of the hypothesis words that overlap
+        // on each stream with the current block of reference utterances
+        for (size_t s = 0; s < hypothesis.size(); s++) {
+            // Find which words overlap with the current reference block, i.e., which portion of the state
+            // has to be computed
+
+            while (
+                new_state_offset.at(s) < hypothesis.at(s).size()
+                && extended_hypothesis_timings.at(s).at(new_state_offset.at(s)).earliest_end_time <
+                current_reference_utterance.begin_time
+            ) {
+                new_state_offset.at(s)++;
+            }
+//            new_state_end.at(s) = new_state_offset.at(s);
+            new_state_end.at(s) = 0;
+            while (
+                new_state_end.at(s) < hypothesis.at(s).size()
+                && extended_hypothesis_timings.at(s).at(new_state_end.at(s)).latest_begin_time <
+                current_reference_utterance.end_time
+            ) {
+                new_state_end.at(s)++;
+            }
+        }
+
+        // Compute new cells
+        // We only have one possible previous state for ORC-WER! (since there
+        // is only one speaker)
+        Layout target_layout = make_layout(new_state_offset, new_state_end);
+        auto first_update = true;
+        StateEntry new_state = {
+            .cost=std::vector<HypStateEntry>(target_layout.total_size),
+            .layout=target_layout,
+            .offset=new_state_offset,
+        };
+//            printf("new_state size: %d\n", new_state.cost.size());
+//            printf("new_state layout: "); for (auto i : new_state.layout.dimensions) printf(" %d", i); printf("\n");
+
+        auto & prev_state = state; // TODO: rename. We don't need two pointers to the same object
+
+        auto &active_reference = reference.at(u);
+        auto &active_reference_timings = extended_reference_timings.at(u);
+
+        // Compute the update for every hypothesis stream and min over that
+        for (unsigned int s = 0; s < hypothesis.size(); s++) {
+            // TODO: only iterate over the streams that actually overlap with the current reference
+            unsigned int old_distance = -1;
+            // TODO: eliminate the index vector and multiplications
+            std::vector<unsigned int> new_state_index(new_state.layout.dimensions.size());
+            std::vector<unsigned int> old_state_index(prev_state.layout.dimensions.size());
+            std::vector<unsigned int> old_closest_index(new_state_index.size());
+
+            // Iterate over all starting points of of levenshtein rows along the active_hypothesis_index dimension,
+            // i.e., where new_state_index[s] == 0
+//            printf("Start loop");
+            while(true) {
+//                printf("while loop\n");
+                // Translate the new state index into the old state index
+                for (size_t i = 0; i < old_state_index.size(); i++) {
+                    assert(new_state.offset.at(i) >= prev_state.offset.at(i));
+                    assert(prev_state.offset.at(i) <= new_state_index.at(i) + new_state_offset.at(i));
+                    old_state_index.at(i) = new_state_index.at(i) + new_state_offset.at(i) - prev_state.offset.at(i);
+                }
+
+                // Find the index in prev state that is closest to the new index
+                std::vector<unsigned int> closest_index(new_state_index.size());
+                unsigned int distance = 0;
+                for (size_t i = 0; i < closest_index.size(); i++) {
+                    closest_index[i] = std::min(
+                        (unsigned int) old_state_index[i],
+                        (unsigned int) prev_state.layout.dimensions[i] - 1
+                    );
+                    assert(old_state_index[i] >= closest_index[i]);
+                    distance += old_state_index[i] - closest_index[i];
+                }
+                assert(prev_state.layout.within(closest_index));
+
+                // TODO: store all of them in a hash map to further reduce the number of calls of update_levensthein_row?
+                if (false && old_distance != -1 && old_closest_index == closest_index && distance > old_distance) {
+                    // If the distance is greater than 0 we use an earlier state and fill with insertions.
+                    // The levenshtein is invariant to a constant offset, so we can simply take the
+                    // last row and add the insertions
+                    for (unsigned int s_ = 0; s_ < new_state.layout.dimensions.at(s); s_++) {
+                        tmp_row[s_].cost += distance - old_distance;
+                    }
+                } else {
+                    // Fill temporary row
+                    for (unsigned int s_ = 0; s_ < new_state.layout.dimensions.at(s); s_++) {
+                        if (prev_state.layout.within(closest_index)) {
+                            // Copy from previous state
+                            // We have to add the distance because the states might not be overlapping
+                            tmp_row.at(s_).index = prev_state.layout.get_index(closest_index);
+                            tmp_row.at(s_).cost = prev_state.cost.at(tmp_row.at(s_).index ).cost + distance;
+                        } else {
+                            // Pad with insertions
+                            assert(s_ > 0);
+                            tmp_row.at(s_).index = tmp_row.at(s_ - 1).index;
+                            tmp_row.at(s_).cost = tmp_row.at(s_ - 1).cost + 1;
+                        }
+
+                        // Increment state index to move along with s_.
+                        // This might move closest_index out of the prev_state area
+                        closest_index[s]++;
+                    }
+
+//                            printf("Forwarding Levenshtein row (d: %d, u: %d, s: %d, length: %d)\n", d, indices.at(d) - 1, s, new_state_end.at(s) - new_state_offset.at(s));
+//                            printf("tmp_row ["); for (UpdateState i : tmp_row) printf(" %d", i.cost); printf("] -> ");
+                    // Forward tmp row
+                    update_levenshtein_row(
+                        tmp_row,
+                        active_reference,
+                        hypothesis.at(s),
+                        active_reference_timings,
+                        extended_hypothesis_timings.at(s),
+                        new_state.offset.at(s),
+                        new_state_end.at(s)
+                    );
+                }
+                old_distance = distance;
+                old_closest_index = closest_index;
+
+//                        printf("%d [", distance); for (int i =0; i < new_state_end.at(s) - new_state_offset.at(s); i++) printf(" %d", tmp_row.at(i).cost); printf("]\n");
+//                        printf("["); for (UpdateState i : tmp_row) printf(" %d", i.cost); printf("]\n");
+                // Copy into state
+                assert(new_state_index[s] == 0);
+                for (unsigned int s_ = 0; s_ < new_state.layout.dimensions.at(s); s_++) {
+                    auto _index = new_state.layout.get_index(new_state_index);
+
+                    if (first_update || tmp_row.at(s_).cost < new_state.cost[_index].cost) {
+                        new_state.cost[_index].cost = tmp_row.at(s_).cost;
+                        new_state.cost[_index].path = std::make_shared<struct Path>(Path{
+                            .previous=prev_state.cost.at(tmp_row.at(s_).index).path,
+                            .speaker=0, // TODO: this is always 0 for ORC-WER
+                            .utterance=u,
+                            .stream=s
+                        });
+                    }
+                    new_state_index[s]++;
+                }
+
+                new_state_index[s] = 0;
+//                printf("new_state_index:"); for (auto i : new_state_index) printf(" %d", i); printf("\n");
+                if (!new_state.layout.advance_index(new_state_index, s)) break;
+            }
+            first_update = false;
+        }
+        state = new_state;
+    }
+
+    auto final_state = state;
+    unsigned int cost = final_state.cost.back().cost;
+
+    // Handle any words in the hypothesis that begin after the last reference ended
+    for (size_t d = 0; d < num_hypothesis_streams; d++) {
+        if (hypothesis.at(d).size() > final_state.offset.at(d) + final_state.layout.dimensions.at(d) - 1) {
+            cost += hypothesis.at(d).size() - final_state.offset.at(d) - final_state.layout.dimensions.at(d) + 1;
+        }
+    }
+
+    // Get assignment
+    // [(reference speaker index, hypothesis stream index)]
+    std::vector<std::pair<unsigned int, unsigned int>> assignment;
+    Path path = *final_state.cost.back().path;
+
+    while (true) {
+        assignment.push_back({path.speaker, path.stream});
+        if (path.previous) {
+            path = *path.previous;
+        } else {
+            break;
+        }
+    }
+    std::reverse(assignment.begin(), assignment.end());
+    return std::make_pair(cost, assignment);
+}

--- a/meeteval/wer/wer/time_constrained_orc.py
+++ b/meeteval/wer/wer/time_constrained_orc.py
@@ -1,0 +1,122 @@
+import meeteval
+from meeteval.wer import ErrorRate
+from meeteval.wer.wer.orc import OrcErrorRate
+from meeteval.wer.wer.utils import check_single_filename
+
+
+def time_constrained_orc_wer(
+        reference,
+        hypothesis,
+        collar=0,
+        reference_pseudo_word_level_timing='character_based',
+        hypothesis_pseudo_word_level_timing='character_based_points',
+        hypothesis_sort='segment',
+):
+    """
+    The time-constrained version of the ORC-WER (tcORC-WER).
+
+    Special cases where the reference or hypothesis is empty
+    >>> time_constrained_orc_wer([], [])
+    OrcErrorRate(errors=0, length=0, insertions=0, deletions=0, substitutions=0, assignment=())
+    >>> time_constrained_orc_wer([], [{'session_id': 'a', 'start_time': 0, 'end_time': 1, 'words': 'a', 'speaker': 'A'}])
+    OrcErrorRate(errors=1, length=0, insertions=1, deletions=0, substitutions=0, assignment=())
+    >>> time_constrained_orc_wer([{'session_id': 'a', 'start_time': 0, 'end_time': 1, 'words': 'a', 'speaker': 'A'}], [])
+    OrcErrorRate(error_rate=1.0, errors=1, length=1, insertions=0, deletions=1, substitutions=0, assignment=())
+    """
+    # Convert to seglst
+    reference = meeteval.io.asseglst(reference)
+    hypothesis = meeteval.io.asseglst(hypothesis)
+    check_single_filename(reference, hypothesis)
+
+    # Remove empty segments
+    reference = reference.filter(lambda s: s['words'] != '')
+    hypothesis = hypothesis.filter(lambda s: s['words'] != '')
+
+    # Add a segment index to the reference so that we can later find words that
+    # come from the same segment
+    for i, s in enumerate(reference):
+        s['segment_index'] = i
+
+    # Group by stream
+    hypothesis = hypothesis.groupby('speaker')
+
+    # Time-constrained preprocessing
+    from meeteval.wer.wer.time_constrained import sort_and_validate, apply_collar
+    reference = sort_and_validate(
+        reference,
+        'segment',
+        reference_pseudo_word_level_timing,
+        f'reference'
+    )
+    hypothesis = {
+        k: apply_collar(sort_and_validate(
+            h,
+            hypothesis_sort,
+            hypothesis_pseudo_word_level_timing,
+            f'hypothesis speaker "{k}"'
+        ), collar) for k, h in hypothesis.items()
+    }
+
+    # TODO: compute self-overlap
+
+    from meeteval.wer.matching.cy_time_constrained_orc_matching import time_constrained_orc_levenshtein_distance
+
+    distance, assignment = time_constrained_orc_levenshtein_distance(
+        [segment.T['words'] for segment in reference.groupby('segment_index').values()],
+        [stream.T['words'] for stream in hypothesis.values()],
+        [list(zip(segment.T['start_time'], segment.T['end_time'])) for segment in reference.groupby('segment_index').values()],
+        [list(zip(stream.T['start_time'], stream.T['end_time'])) for stream in hypothesis.values()],
+    )
+
+    hypothesis_keys = list(hypothesis.keys())
+    assignment = [hypothesis_keys[h] for r, h in assignment]
+
+    # Apply assignment in seglst format
+    r_ = list(reference.groupby('segment_index').values()) # Shallow copy because we pop later
+    if assignment:
+        reference_new = []
+        for h in assignment:
+            for w in r_.pop(0):
+                reference_new.append({**w, 'speaker': h})
+        reference_new = meeteval.io.SegLST(reference_new).groupby('speaker')
+    else:
+        reference_new = reference.groupby('speaker')
+
+    from meeteval.wer.wer.time_constrained import _time_constrained_siso_error_rate
+    er = sum([
+        _time_constrained_siso_error_rate(
+            reference_new.get(k, meeteval.io.SegLST([])),
+            hypothesis.get(k, meeteval.io.SegLST([])),
+        )
+        for k in set(hypothesis.keys()) | set(reference_new.keys())
+    ], start=ErrorRate(0, 0, 0, 0, 0, None, None))
+    length = len(reference)
+    assert er.length == length, (length, er)
+    assert er.errors == distance, (distance, er, assignment)
+
+    return OrcErrorRate(
+        er.errors, er.length,
+        insertions=er.insertions,
+        deletions=er.deletions,
+        substitutions=er.substitutions,
+        assignment=tuple(assignment),
+        reference_self_overlap=None,
+        hypothesis_self_overlap=None,
+    )
+
+def time_constrained_orc_wer_multifile(
+        reference: 'STM', hypothesis: 'STM',
+        reference_pseudo_word_level_timing='character_based',
+        hypothesis_pseudo_word_level_timing='character_based_points',
+        collar: int = 0,
+        hypothesis_sort='segment',
+) -> 'Dict[str, CPErrorRate]':
+    from meeteval.io.seglst import apply_multi_file
+    r = apply_multi_file(lambda r, h: time_constrained_orc_wer(
+        r, h,
+        reference_pseudo_word_level_timing=reference_pseudo_word_level_timing,
+        hypothesis_pseudo_word_level_timing=hypothesis_pseudo_word_level_timing,
+        collar=collar,
+        hypothesis_sort=hypothesis_sort,
+    ), reference, hypothesis)
+    return r

--- a/meeteval/wer/wer/utils.py
+++ b/meeteval/wer/wer/utils.py
@@ -1,22 +1,32 @@
-def _check_valid_input_files(reference, hypothesis):
-    if type(reference) != type(hypothesis):
+from meeteval.io import SegLST
+
+
+def check_single_filename(reference: SegLST, hypothesis: SegLST):
+    try:
+        reference_session_ids = reference.unique('session_id')
+    except KeyError:
+        reference_session_ids = set()
+    try:
+        hypothesis_session_ids = hypothesis.unique('session_id')
+    except KeyError:
+        hypothesis_session_ids = set()
+
+    if len(reference_session_ids) > 1:
         raise ValueError(
-            f'Both reference and hypothesis must be of the same type, but found {type(reference)} and {type(hypothesis)}.'
+            f"Expected a single session ID, but got "
+            f"{len(reference_session_ids)} in the reference: "
+            f"{reference_session_ids}"
         )
 
-    # Check single filename
-    if len(reference.filenames()) > 1:
+    if len(hypothesis_session_ids) > 1:
         raise ValueError(
-            f'Reference must contain exactly one file, but found {len(reference.filenames())} files.'
-        )
-    if len(hypothesis.filenames()) > 1:
-        raise ValueError(
-            f'Hypothesis must contain exactly one file, but found {len(hypothesis.filenames())} files.'
+            f"Expected a single session ID, but got "
+            f"{len(hypothesis_session_ids)} in the hypothesis: "
+            f"{hypothesis_session_ids}"
         )
 
-    # Check same filename
-    if reference.filenames() != hypothesis.filenames():
+    if len(reference) > 0 and len(hypothesis) > 0 and reference_session_ids != hypothesis_session_ids:
         raise ValueError(
-            f'Both reference and hypothesis must have the same filename, but found {reference.filenames()} '
-            f'and {hypothesis.filenames()}.'
+            f"Expected the same session ID in reference and hypothesis, but "
+            f"got {reference_session_ids} and {hypothesis_session_ids}"
         )

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,12 @@ ext_modules = cythonize(
             extra_compile_args=['-std=c++11'],
             extra_link_args=['-std=c++11'],
         ),
+        Extension(
+            'meeteval.wer.matching.cy_time_constrained_orc_matching',
+            ['meeteval/wer/matching/cy_time_constrained_orc_matching.pyx'],
+            extra_compile_args=['-std=c++11'],
+            extra_link_args=['-std=c++11'],
+        ),
      ]
 )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -103,6 +103,14 @@ def test_burn_tcp():
     run(f'python -m meeteval.wer tcpwer -h hyp.stm -r ref.stm --reference-sort word --hypothesis-sort true')
 
 
+def test_burn_tcorc():
+    run(f'python -m meeteval.wer tcorcwer -h hyp.stm -r ref.stm')
+    run(f'python -m meeteval.wer tcorcwer -h hyp.stm -r ref.stm --collar 5')
+    run(f'python -m meeteval.wer tcorcwer -h hyp.stm -r ref.stm --hyp-pseudo-word-timing equidistant_points')
+    run(f'python -m meeteval.wer tcorcwer -h hyp.seglst.json -r ref.seglst.json')
+    run(f'python -m meeteval.wer tcorcwer -h hyp.stm -r ref.stm --hypothesis-sort true')
+
+
 def test_burn_md_eval_22():
     run(f'python -m meeteval.der md_eval_22 -h hyp.stm -r ref.stm')
     run(f'meeteval-der md_eval_22 -h hyp.stm -r ref.stm')


### PR DESCRIPTION
This PR adds code to compute the tcORC-WER.

Example:

```shell
python -m meeteval.wer tcorcwer -h hyp.stm -r ref.stm --collar 5
```

The current version is tested on Libri-CSS with a system that produces 8 streams. It finished computation within 10 minutes and used less than 2GB of RAM (which is a huge improvement over ORC-WER!). These requirements should drop further when the number of streams is smaller.

The code is not fully optimized yet and contains many TODOs. I'll work on some of these TODOs and update the PR during the next few days.

I'll merge main back into this PR once #50 is merged.