### PR TITLE
Rework overview table

### DIFF
--- a/meeteval/viz/__main__.py
+++ b/meeteval/viz/__main__.py
@@ -104,23 +104,32 @@ def create_viz_folder(
                 pass
             doc.asis('<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.31.2/css/theme.default.min.css">')
             with tag('style'):
-                doc.asis('''
+                n = len(alignments.split(','))
+                doc.asis(f'''
                     /* Center table */
-                    body {
+                    body {{
                         width: fit-content;
                         margin: 0 auto;
-                    }
+                    }}
                     /* Make numbers monospace and right-aligned (aligns the decimal point) */
-                    .number {
+                    .number {{
                         font-family: monospace;
                         text-align: right;
-                    }
-                    td {
+                    }}
+                    td {{
                         text-align: right;
-                    }
-                    td:nth-child(1) {
+                    }}
+                    td:nth-child(1) {{
                         text-align: left;
-                    }
+                    }}
+                    tbody tr:nth-child(odd) td {{
+                      background-color: #f2f2f2;
+                    }}
+                    tbody td:nth-child({n}n+2), 
+                    thead tr:nth-child(2) th:nth-child({n}n+2),
+                    thead tr:nth-child(1) th{{
+                        padding-left: 3em;
+                    }}
                 ''')
         with tag('body'):
             with tag('table', klass='tablesorter', id='myTable', style='width: auto;'):
@@ -144,7 +153,8 @@ def create_viz_folder(
 
                         for (k, alignment), v in avs.items():
                             with tag('th'):
-                                doc.text(f'{alignment}WER: ')
+                                doc.asis(f'{alignment}WER<br>')
+
                                 with tag('span', klass='number'):
                                     doc.text(get_wer(v))
 

--- a/meeteval/viz/__main__.py
+++ b/meeteval/viz/__main__.py
@@ -103,19 +103,54 @@ def create_viz_folder(
             with tag('script', src='https://cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.31.2/js/jquery.tablesorter.min.js'):
                 pass
             doc.asis('<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.31.2/css/theme.default.min.css">')
+            with tag('style'):
+                doc.asis('''
+                    /* Center table */
+                    body {
+                        width: fit-content;
+                        margin: 0 auto;
+                    }
+                    /* Make numbers monospace and right-aligned (aligns the decimal point) */
+                    .number {
+                        font-family: monospace;
+                        text-align: right;
+                    }
+                    td {
+                        text-align: right;
+                    }
+                    td:nth-child(1) {
+                        text-align: left;
+                    }
+                ''')
         with tag('body'):
             with tag('table', klass='tablesorter', id='myTable', style='width: auto;'):
-                with tag('thead'), tag('tr'):
-                    for s in [
-                        'Session ID',
-                        *[
-                            col
-                            for (k, alignment), v in avs.items()
-                            for col in [k, f'{alignment}WER: {get_wer(v)}']
-                        ]
-                    ]:
+                with tag('thead'):
+                    with tag('tr'):
+                        with tag('th', ('data-sorter', 'false')):
+                            pass
+
+                        for system, item in itertools.groupby(avs.items(), key=lambda x: x[0][0]):
+                            with tag('th', ('data-sorter', "false"), colspan=len(list(item))):
+                                doc.text(system)
+
+                        if ',' in alignments or len(hypothesiss) > 1:
+                            with tag('th', ('data-sorter', "false"), colspan=2):
+                                with tag('span', klass='synced-view'):
+                                    pass
+
+                    with tag('tr'):
                         with tag('th'):
-                            doc.text(s)
+                            doc.text('Session ID')
+
+                        for (k, alignment), v in avs.items():
+                            with tag('th'):
+                                doc.text(f'{alignment}WER: ')
+                                with tag('span', klass='number'):
+                                    doc.text(get_wer(v))
+
+                        if ',' in alignments or len(hypothesiss) > 1:
+                            with tag('th', ('data-sorter', "false"), colspan=2):
+                                doc.text("Side-by-side views")
 
                 with tag('tbody'):
                     for session_id, v in avs_T.items():


### PR DESCRIPTION
Reorders and groups columns from the same system. Numbers are now displayed with a monospaced font and aligned at the decimal dot. The sorting state is stored in the URL so that hitting the back button in the browser returns to the earlier state.

This is an example:
![image](https://github.com/fgnt/meeteval/assets/25043715/f32f3cc1-c3b9-47f8-8247-4bb0e8ea80f5)
with the sort encoded like this in the URL: `.../index.html?sort=1&order=descending`
