### PR TITLE
Unify preprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ wer = meeteval.wer.wer.cp.cp_word_error_rate(
     hypothesis = meeteval.io.STM.parse('recordingA 1 spk-1 0 1 The kwick brown fox jump over lazy ')
 )
 print(wer)
-# CPErrorRate(error_rate=0.4444444444444444, errors=4, length=9, insertions=0, deletions=2, substitutions=2, missed_speaker=0, falarm_speaker=0, scored_speaker=1, assignment=(('Alice', 'spk-1'),))
+# CPErrorRate(error_rate=0.4444444444444444, errors=4, length=9, insertions=0, deletions=2, substitutions=2, reference_self_overlap=SelfOverlap(overlap_rate=Decimal('0'), overlap_time=0, total_time=Decimal('1')), hypothesis_self_overlap=SelfOverlap(overlap_rate=Decimal('0'), overlap_time=0, total_time=Decimal('1')), missed_speaker=0, falarm_speaker=0, scored_speaker=1, assignment=(('Alice', 'spk-1'), ))
 ```
 
 All low-level interfaces come with a single-example function (as show above) and a batch function that computes the WER for multiple examples at once.

--- a/example_files/hyp.seglst.json
+++ b/example_files/hyp.seglst.json
@@ -4,41 +4,47 @@
     "session_id": "recordingA",
     "speaker": "Alice",
     "start_time": "0",
-    "words": "Effort made was a lot i know your busy we need two make the new version clean"
+    "words": "Effort made was a lot i know your busy we need two make the new version clean",
+    "custom_key": "custom_value"
   },
   {
     "end_time": "2.5",
     "session_id": "recordingA",
     "speaker": "Bob",
     "start_time": "1",
-    "words": "Strategic staircase we need a paradigm shift"
+    "words": "Strategic staircase we need a paradigm shift",
+    "custom_key": "custom_value"
   },
   {
     "end_time": "3",
     "session_id": "recordingA",
     "speaker": "Alice",
     "start_time": "2.1",
-    "words": "Pipeline Bob called an all-hands this afternoon"
+    "words": "Pipeline Bob called an all-hands this afternoon",
+    "custom_key": "custom_value"
   },
   {
     "end_time": "4.6",
     "session_id": "recordingB",
     "speaker": "Bob",
     "start_time": "3.2",
-    "words": "Hop on the bandwagon let's schedule a standup during the sprint to review our kpis"
+    "words": "Hop on the bandwagon let's schedule a standup during the sprint to review our kpis",
+    "custom_key": "custom_value"
   },
   {
     "end_time": "5",
     "session_id": "recordingB",
     "speaker": "Alice",
     "start_time": "4",
-    "words": "Hop on the bandwagon let's review our kpis"
+    "words": "Hop on the bandwagon let's review our kpis",
+    "custom_key": "custom_value"
   },
   {
     "end_time": "6",
     "session_id": "recordingA",
     "speaker": "Alice",
     "start_time": "5",
-    "words": "Organic growth what do you feel you would bring to the table if you were hired for this position it just needs more cowbell, yet groom the backlog, land the plane"
+    "words": "Organic growth what do you feel you would bring to the table if you were hired for this position it just needs more cowbell, yet groom the backlog, land the plane",
+    "custom_key": "custom_value"
   }
 ]

--- a/example_files/hypA.stm
+++ b/example_files/hypA.stm
@@ -1,4 +1,4 @@
 recordingA 0 Alice 0 0 Effort made was a lot i know your busy we need two make the new version clean
-recordingA 0 Bob 1 0 Strategic staircase we need a paradigm shift
-recordingA 0 Alice 2 0 Pipeline Bob called an all-hands this afternoon
-recordingA 0 Alice 5 0 Organic growth what do you feel you would bring to the table if you were hired for this position it just needs more cowbell, yet groom the backlog, land the plane
+recordingA 0 Bob 1 2 Strategic staircase we need a paradigm shift
+recordingA 0 Alice 2 3 Pipeline Bob called an all-hands this afternoon
+recordingA 0 Alice 5 6 Organic growth what do you feel you would bring to the table if you were hired for this position it just needs more cowbell, yet groom the backlog, land the plane

--- a/example_files/hypB.stm
+++ b/example_files/hypB.stm
@@ -1,2 +1,2 @@
-recordingB 0 Bob 3 0 Hop on the bandwagon let's schedule a standup during the sprint to review our kpis
-recordingB 0 Alice 4 0 Hop on the bandwagon let's review our kpis
+recordingB 0 Bob 3 4 Hop on the bandwagon let's schedule a standup during the sprint to review our kpis
+recordingB 0 Alice 4 5 Hop on the bandwagon let's review our kpis

--- a/example_files/refA.stm
+++ b/example_files/refA.stm
@@ -1,4 +1,4 @@
-recordingA 0 Alice 0 0 Effort made was a lot i know you're busy we need to make the new version clean
-recordingA 0 Bob 1 0 Strategic staircase we need a paradigm shift
-recordingA 0 Alice 2 0 Pipeline Bob called an all-hands this afternoon
-recordingA 0 Alice 5 0 Organic growth what do you feel you would bring to the table if you were hired for this position it just needs more cowbell, yet groom the backlog, land the plane
+recordingA 0 Alice 0 1 Effort made was a lot i know you're busy we need to make the new version clean
+recordingA 0 Bob 1 2 Strategic staircase we need a paradigm shift
+recordingA 0 Alice 2 3 Pipeline Bob called an all-hands this afternoon
+recordingA 0 Alice 5 6 Organic growth what do you feel you would bring to the table if you were hired for this position it just needs more cowbell, yet groom the backlog, land the plane

--- a/example_files/refB.stm
+++ b/example_files/refB.stm
@@ -1,2 +1,2 @@
-recordingB 0 Alice 3 0 Hop on the bandwagon let's schedule a standup during the sprint to review our kpis
-recordingB 0 Alice 4 0 Hop on the bandwagon let's schedule a standup during the sprint to review our kpis
+recordingB 0 Alice 3 4 Hop on the bandwagon let's schedule a standup during the sprint to review our kpis
+recordingB 0 Alice 4 5 Hop on the bandwagon let's schedule a standup during the sprint to review our kpis

--- a/meeteval/io/seglst.py
+++ b/meeteval/io/seglst.py
@@ -33,9 +33,9 @@ class SegLstSegment(TypedDict, total=False):
         We do not define an enum with all these keys for speed reasons
     """
     session_id: str
-    start_time: 'float | decimal.Decimal'
-    end_time: 'float | decimal.Decimal'
-    words: str
+    start_time: 'float | decimal.Decimal | list[float | decimal.Decimal]'
+    end_time: 'float | decimal.Decimal | list[float | decimal.Decimal]'
+    words: 'str | list[str]'
     speaker: str
     segment_index: int
 
@@ -182,11 +182,14 @@ class SegLST(BaseABC):
                 *[set(s.keys()) for s in self._outer.segments]
             )
 
-        def __getitem__(self, key: _SegLstSegment_keys):
+        def __getitem__(self, key: '_SegLstSegment_keys | tuple[_SegLstSegment_keys, ...]'):
             """
             Returns the values for `key` of all segments as a list.
             """
-            return [s[key] for s in self._outer.segments]
+            if isinstance(key, (list, tuple)):
+                return [tuple([s[k] for k in key]) for s in self._outer.segments]
+            else:
+                return [s[key] for s in self._outer.segments]
 
         def get(self, key, default=None):
             """
@@ -195,7 +198,7 @@ class SegLST(BaseABC):
             """
             return [s.get(key, default) for s in self._outer.segments]
 
-        def __class_getitem__(cls, item: _SegLstSegment_keys) -> 'list':
+        def __class_getitem__(cls, item: '_SegLstSegment_keys | tuple[_SegLstSegment_keys, ...]') -> 'list':
             """
             This is a dummy for type annotation.
 

--- a/meeteval/viz/__main__.py
+++ b/meeteval/viz/__main__.py
@@ -28,10 +28,11 @@ def create_viz_folder(
 
         r, h = _load_texts(
             reference, hypothesis, regex=regex,
-            reference_sort='segment',
-            hypothesis_sort='segment',
             normalizer=normalizer,
         )
+
+        r = r.sorted('start_time')
+        h = h.sorted('start_time')
 
         r = r.groupby('session_id')
         h = h.groupby('session_id')

--- a/meeteval/wer/__main__.py
+++ b/meeteval/wer/__main__.py
@@ -165,8 +165,8 @@ def orcwer(
         average_out='{parent}/{stem}_orcwer.json',
         per_reco_out='{parent}/{stem}_orcwer_per_reco.json',
         regex=None,
-        reference_sort='maybe_segment',
-        hypothesis_sort='maybe_segment',
+        reference_sort='segment_if_available',
+        hypothesis_sort='segment_if_available',
         uem=None,
         partial=False,
         normalizer=None,
@@ -187,8 +187,8 @@ def cpwer(
         average_out='{parent}/{stem}_cpwer.json',
         per_reco_out='{parent}/{stem}_cpwer_per_reco.json',
         regex=None,
-        reference_sort='maybe_segment',
-        hypothesis_sort='maybe_segment',
+        reference_sort='segment_if_available',
+        hypothesis_sort='segment_if_available',
         uem=None,
         normalizer=None,
         partial=False,
@@ -207,8 +207,8 @@ def mimower(
         average_out='{parent}/{stem}_mimower.json',
         per_reco_out='{parent}/{stem}_mimower_per_reco.json',
         regex=None,
-        reference_sort='maybe_segment',
-        hypothesis_sort='maybe_segment',
+        reference_sort='segment_if_available',
+        hypothesis_sort='segment_if_available',
         uem=None,
         normalizer=None,
         partial=False,
@@ -490,7 +490,8 @@ class CLI:
                      '- True: Sort by segment start time and assert that the word-level timings are sorted by start '
                      'time. Only supported for time-constrained WERs\n'
                      '- word: sort words by start time. Only supported for time-constrained WERs\n'
-                     '- maybe_segment: Same as segment, but only applies when timestamps are present in the inputs'
+                     '- segment_if_available: Same as segment, but only applies when timestamps are present in the '
+                     'inputs. If no timestamps are present, falls back to False.'
             )
         elif name == 'hypothesis_sort':
             command_parser.add_argument(
@@ -505,7 +506,8 @@ class CLI:
                      '- True: Sort by segment start time and assert that the word-level timings are sorted by start '
                      'time. Only supported for time-constrained WERs\n'
                      '- word: sort words by start time. Only supported for time-constrained WERs\n'
-                     '- maybe_segment: Same as segment, but only applies when timestamps are present in the inputs'
+                     '- segment_if_available: Same as segment, but only applies when timestamps are present in the '
+                     'inputs. If no timestamps are present, falls back to False.'
             )
         elif name == 'uem':
             command_parser.add_argument(

--- a/meeteval/wer/__main__.py
+++ b/meeteval/wer/__main__.py
@@ -165,8 +165,8 @@ def orcwer(
         average_out='{parent}/{stem}_orcwer.json',
         per_reco_out='{parent}/{stem}_orcwer_per_reco.json',
         regex=None,
-        reference_sort='segment',
-        hypothesis_sort='segment',
+        reference_sort='maybe_segment',
+        hypothesis_sort='maybe_segment',
         uem=None,
         partial=False,
         normalizer=None,
@@ -187,8 +187,8 @@ def cpwer(
         average_out='{parent}/{stem}_cpwer.json',
         per_reco_out='{parent}/{stem}_cpwer_per_reco.json',
         regex=None,
-        reference_sort='segment',
-        hypothesis_sort='segment',
+        reference_sort='maybe_segment',
+        hypothesis_sort='maybe_segment',
         uem=None,
         normalizer=None,
         partial=False,
@@ -207,8 +207,8 @@ def mimower(
         average_out='{parent}/{stem}_mimower.json',
         per_reco_out='{parent}/{stem}_mimower_per_reco.json',
         regex=None,
-        reference_sort='segment',
-        hypothesis_sort='segment',
+        reference_sort='maybe_segment',
+        hypothesis_sort='maybe_segment',
         uem=None,
         normalizer=None,
         partial=False,
@@ -489,7 +489,8 @@ class CLI:
                      'and sorting is up to the user\n'
                      '- True: Sort by segment start time and assert that the word-level timings are sorted by start '
                      'time. Only supported for time-constrained WERs\n'
-                     '- word: sort words by start time. Only supported for time-constrained WERs'
+                     '- word: sort words by start time. Only supported for time-constrained WERs\n'
+                     '- maybe_segment: Same as segment, but only applies when timestamps are present in the inputs'
             )
         elif name == 'hypothesis_sort':
             command_parser.add_argument(
@@ -503,7 +504,8 @@ class CLI:
                      'and sorting is up to the user\n'
                      '- True: Sort by segment start time and assert that the word-level timings are sorted by start '
                      'time. Only supported for time-constrained WERs\n'
-                     '- word: sort words by start time. Only supported for time-constrained WERs'
+                     '- word: sort words by start time. Only supported for time-constrained WERs\n'
+                     '- maybe_segment: Same as segment, but only applies when timestamps are present in the inputs'
             )
         elif name == 'uem':
             command_parser.add_argument(

--- a/meeteval/wer/api.py
+++ b/meeteval/wer/api.py
@@ -40,8 +40,6 @@ def _load_texts(
         reference_paths: 'list[str]',
         hypothesis_paths: 'list[str]',
         regex,
-        reference_sort: 'bool | str' = False,
-        hypothesis_sort: 'bool | str' = False,
         file_format=None,
         normalizer=None,
         uem=None,
@@ -87,46 +85,6 @@ def _load_texts(
         reference = reference.filter_by_uem(uem)
         hypothesis = hypothesis.filter_by_uem(uem)
 
-    # Sort
-    if reference_sort == 'segment':
-        if 'start_time' in reference.T.keys():
-            reference = reference.sorted('start_time')
-        else:
-            logging.warning(
-                'Ignoring --reference-sort="segment" because no start_time is '
-                'found in the reference'
-            )
-    elif not reference_sort:
-        pass
-    elif reference_sort in ('word', True):
-        raise ValueError(
-            f'reference_sort={reference_sort} is only supported for'
-            f'time-constrained WERs.'
-        )
-    else:
-        raise ValueError(
-            f'Unknown choice for reference_sort: {reference_sort}'
-        )
-    if hypothesis_sort == 'segment':
-        if 'start_time' in hypothesis.T.keys():
-            hypothesis = hypothesis.sorted('start_time')
-        else:
-            logging.warning(
-                'Ignoring --hypothesis-sort="segment" because no start_time is '
-                'found in the hypothesis'
-            )
-    elif not hypothesis_sort:
-        pass
-    elif hypothesis_sort in ('word', True):
-        raise ValueError(
-            f'hypothesis_sort={hypothesis_sort} is only supported for'
-            f'time-constrained WERs.'
-        )
-    else:
-        raise ValueError(
-            f'Unknown choice for hypothesis_sort: {hypothesis_sort}'
-        )
-
     if normalizer is not None:
         if normalizer == 'lower,rm(.?!,)':
             def normalizer(seg):
@@ -153,10 +111,13 @@ def orcwer(
     from meeteval.wer.wer.orc import orc_word_error_rate_multifile
     reference, hypothesis = _load_texts(
         reference, hypothesis, regex=regex,
-        reference_sort=reference_sort, hypothesis_sort=hypothesis_sort,
         uem=uem, normalizer=normalizer,
     )
-    results = orc_word_error_rate_multifile(reference, hypothesis, partial=partial)
+    results = orc_word_error_rate_multifile(
+        reference, hypothesis, partial=partial,
+        reference_sort=reference_sort,
+        hypothesis_sort=hypothesis_sort,
+    )
     return results
 
 
@@ -173,10 +134,13 @@ def cpwer(
     from meeteval.wer.wer.cp import cp_word_error_rate_multifile
     reference, hypothesis = _load_texts(
         reference, hypothesis, regex=regex,
-        reference_sort=reference_sort, hypothesis_sort=hypothesis_sort,
         uem=uem, normalizer=normalizer,
     )
-    results = cp_word_error_rate_multifile(reference, hypothesis, partial=partial)
+    results = cp_word_error_rate_multifile(
+        reference, hypothesis, partial=partial,
+        reference_sort=reference_sort,
+        hypothesis_sort=hypothesis_sort,
+    )
     return results
 
 
@@ -193,10 +157,14 @@ def mimower(
     from meeteval.wer.wer.mimo import mimo_word_error_rate_multifile
     reference, hypothesis = _load_texts(
         reference, hypothesis, regex=regex,
-        reference_sort=reference_sort, hypothesis_sort=hypothesis_sort,
         uem=uem, normalizer=normalizer
     )
-    results = mimo_word_error_rate_multifile(reference, hypothesis, partial=partial)
+    results = mimo_word_error_rate_multifile(
+        reference, hypothesis,
+        partial=partial,
+        reference_sort=reference_sort,
+        hypothesis_sort=hypothesis_sort
+    )
     return results
 
 

--- a/meeteval/wer/api.py
+++ b/meeteval/wer/api.py
@@ -101,8 +101,8 @@ def _load_texts(
 def orcwer(
         reference, hypothesis,
         regex=None,
-        reference_sort='segment',
-        hypothesis_sort='segment',
+        reference_sort='segment_if_available',
+        hypothesis_sort='segment_if_available',
         uem=None,
         partial=False,
         normalizer=None,
@@ -124,8 +124,8 @@ def orcwer(
 def cpwer(
         reference, hypothesis,
         regex=None,
-        reference_sort='segment',
-        hypothesis_sort='segment',
+        reference_sort='segment_if_available',
+        hypothesis_sort='segment_if_available',
         uem=None,
         normalizer=None,
         partial=False
@@ -147,8 +147,8 @@ def cpwer(
 def mimower(
         reference, hypothesis,
         regex=None,
-        reference_sort='segment',
-        hypothesis_sort='segment',
+        reference_sort='segment_if_available',
+        hypothesis_sort='segment_if_available',
         uem=None,
         normalizer=None,
         partial=False,

--- a/meeteval/wer/preprocess.py
+++ b/meeteval/wer/preprocess.py
@@ -83,7 +83,7 @@ def add_segment_index(d: SegLST):
 def preprocess(
         reference, hypothesis,
         segment_index='segment',
-        convert_to_int=True,
+        convert_to_int=False,
         remove_empty_segments=True,
 ):
     """
@@ -101,12 +101,16 @@ def preprocess(
     if 'begin_time' in reference.T.keys() and 'end_time' in reference.T.keys():
         from meeteval.wer.wer.time_constrained import get_self_overlap
         reference_self_overlap = get_self_overlap(reference)
+        if reference_self_overlap.total_time == 0:
+            reference_self_overlap = None
     else:
         reference_self_overlap = None
 
     if 'begin_time' in hypothesis.T.keys() and 'end_time' in hypothesis.T.keys():
         from meeteval.wer.wer.time_constrained import get_self_overlap
         hypothesis_self_overlap = get_self_overlap(hypothesis)
+        if hypothesis_self_overlap.total_time == 0:
+            hypothesis_self_overlap = None
     else:
         hypothesis_self_overlap = None
 

--- a/meeteval/wer/preprocess.py
+++ b/meeteval/wer/preprocess.py
@@ -54,7 +54,7 @@ def split_words(
 
     def split_entry(x):
         if isinstance(x, str):
-            return x.split() # or ['']
+            return x.split()  # or ['']
         elif isinstance(x, (list, tuple)):
             return x
         else:
@@ -113,10 +113,10 @@ def split_words(
 
 def merge_segments(
         d: SegLST,
-        merge_by: str | tuple[str],
-        merge_keys: tuple[str],
-        ignore_keys: tuple[str] = (),
-        strict: bool = False,
+        merge_by: 'str | tuple[str]',
+        merge_keys: 'tuple[str]',
+        ignore_keys: 'tuple[str]' = (),
+        strict: 'bool' = False,
 ):
     """
     Group segments by `merge_by` and merge segments.
@@ -192,7 +192,7 @@ def merge_segments(
     return d
 
 
-def words_to_int(*d: SegLST):
+def words_to_int(*d: 'SegLST'):
     """
     Converts all words to ints. The mapping is created by iterating over all
     words in d and assigning an integer to each word.
@@ -215,7 +215,7 @@ def words_to_int(*d: SegLST):
     return d
 
 
-def add_segment_index(d: SegLST):
+def add_segment_index(d: 'SegLST'):
     """
     Adds a segment index to the segments, if not already present.
     """
@@ -225,7 +225,7 @@ def add_segment_index(d: SegLST):
     return d
 
 
-def check_timestamps_valid(seglst: SegLST, name=None):
+def check_timestamps_valid(seglst: 'SegLST', name=None):
     for s in seglst:
         if s['end_time'] < s['start_time']:
             raise ValueError(
@@ -234,7 +234,7 @@ def check_timestamps_valid(seglst: SegLST, name=None):
             )
 
 
-def _select_keys(d: SegLST, keys=(), strict=True):
+def _select_keys(d: 'SegLST', keys=(), strict=True):
     if strict:
         return d.map(lambda x: {k: x[k] for k in keys})
     else:
@@ -242,7 +242,7 @@ def _select_keys(d: SegLST, keys=(), strict=True):
 
 
 def _preprocess_single(
-        segments: SegLST,
+        segments: 'SegLST',
         keep_keys=None,
         sort='segment',
         remove_empty_segments=True,
@@ -458,7 +458,7 @@ def _preprocess_single(
 
 def preprocess(
         reference, hypothesis,
-        keep_keys=None, # None or tuple[str]
+        keep_keys=None,  # None or tuple[str]
         segment_index='segment',
         convert_to_int=False,
         remove_empty_segments=True,
@@ -482,6 +482,7 @@ def preprocess(
 
     reference, reference_self_overlap = _preprocess_single(
         reference,
+        keep_keys=keep_keys,
         segment_index=segment_index,
         remove_empty_segments=remove_empty_segments,
         sort=reference_sort,
@@ -491,6 +492,7 @@ def preprocess(
     )
     hypothesis, hypothesis_self_overlap = _preprocess_single(
         hypothesis,
+        keep_keys=keep_keys,
         segment_index=segment_index,
         remove_empty_segments=remove_empty_segments,
         sort=hypothesis_sort,

--- a/meeteval/wer/preprocess.py
+++ b/meeteval/wer/preprocess.py
@@ -468,6 +468,7 @@ def preprocess(
         reference_pseudo_word_level_timing=None,
         hypothesis_pseudo_word_level_timing=None,
         segment_representation='segment',  # 'segment', 'word', 'speaker'
+        ensure_single_session=True,
 ):
     """
     Preprocessing.
@@ -476,7 +477,8 @@ def preprocess(
     reference = meeteval.io.asseglst(reference)
     hypothesis = meeteval.io.asseglst(hypothesis)
 
-    check_single_filename(reference, hypothesis)
+    if ensure_single_session:
+        check_single_filename(reference, hypothesis)
 
     reference, reference_self_overlap = _preprocess_single(
         reference,

--- a/meeteval/wer/preprocess.py
+++ b/meeteval/wer/preprocess.py
@@ -1,4 +1,5 @@
 import itertools
+import logging
 
 import meeteval
 from meeteval.io import SegLST
@@ -6,42 +7,189 @@ from meeteval.io.pbjson import zip_strict
 from meeteval.io.seglst import seglst_map
 from meeteval.wer.wer.utils import check_single_filename
 
+logger = logging.getLogger('preprocess')
+
 
 @seglst_map()
 def split_words(
         d: 'SegLST',
         *,
-        keys=('words',)
+        keys=('words',),
+        word_level_timing_strategy=None,
+        segment_representation='word',  # 'segment', 'word', 'speaker'
 ):
     """
     Splits segments into words and copies all other entries.
 
-    Uses a word-level timing strategy to convert the segment-level timings
-    into word-level timings. If no strategy is given, the timings are
-    copied as they are.
+    If segment_representation is 'word', every segment in the output will
+    contain a single word (or no word). If segment_representation is 'segment',
+    every segment in the output will contain all words of the original segment
+    as a list. If segment_representation is 'speaker', every segment in the
+    output will contain all words of a single speaker as a list.
 
-    >>> split_words(SegLST([{'words': 'a b c'}]))
-    SegLST(segments=[{'words': 'a'}, {'words': 'b'}, {'words': 'c'}])
+    >>> from paderbox.utils.pretty import pprint
+    >>> pprint(split_words(SegLST([{'words': 'a b c'}])))
+    SegLST([{'words': 'a'}, {'words': 'b'}, {'words': 'c'}])
 
-    >>> split_words(SegLST([{'words': 'a b c', 'start_time': 0, 'end_time': 1}]))
-    SegLST(segments=[{'words': 'a', 'start_time': 0, 'end_time': 1}, {'words': 'b', 'start_time': 0, 'end_time': 1}, {'words': 'c', 'start_time': 0, 'end_time': 1}])
+    >>> pprint(split_words(SegLST([{'words': 'a b c', 'word_timings': [(0, 1), (1, 2), (2, 3)]}]), keys=('words', 'word_timings')))
+    SegLST([{'words': 'a', 'word_timings': (0, 1)},
+            {'words': 'b', 'word_timings': (1, 2)},
+            {'words': 'c', 'word_timings': (2, 3)}])
 
-    >>> split_words(SegLST([{'words': 'a b c', 'word_timings': [(0, 1), (1, 2), (2, 3)]}]), keys=('words', 'word_timings'))
-    SegLST(segments=[{'words': 'a', 'word_timings': (0, 1)}, {'words': 'b', 'word_timings': (1, 2)}, {'words': 'c', 'word_timings': (2, 3)}])
+    >>> pprint(split_words(SegLST([{'words': 'a b c', 'start_time': 0, 'end_time': 1}])))
+    SegLST([{'words': 'a', 'start_time': 0, 'end_time': 1},
+            {'words': 'b', 'start_time': 0, 'end_time': 1},
+            {'words': 'c', 'start_time': 0, 'end_time': 1}])
+
+    >>> pprint(split_words(SegLST([{'words': 'a b c', 'start_time': 0, 'end_time': 3}]), word_level_timing_strategy='character_based_points'))
+    SegLST([{'words': 'a', 'start_time': 0.5, 'end_time': 0.5},
+            {'words': 'b', 'start_time': 1.5, 'end_time': 1.5},
+            {'words': 'c', 'start_time': 2.5, 'end_time': 2.5}])
+
+    >>> pprint(split_words(SegLST([{'words': 'a b c', 'speaker': 'spkA'}, {'words': 'a b c', 'speaker': 'spkB'}, {'words': 'd e f', 'speaker': 'spkA'}]), segment_representation='speaker'))
+    SegLST([{'words': ['a', 'b', 'c', 'd', 'e', 'f'], 'speaker': 'spkA'},
+            {'words': ['a', 'b', 'c'], 'speaker': 'spkB'}])
     """
+    assert 'words' in keys, keys
+
     def split_entry(x):
         if isinstance(x, str):
-            return x.split() or ['']
+            return x.split() # or ['']
         elif isinstance(x, (list, tuple)):
             return x
         else:
             raise TypeError(x)
 
-    return d.flatmap(
-        lambda s: [
-            {**s, **dict(zip_strict(keys, split))}
-            for split in zip_strict(*(split_entry(s[key]) for key in keys))
-        ])
+    keys_ = keys
+    if word_level_timing_strategy is not None:
+        from meeteval.wer.wer.time_constrained import pseudo_word_level_strategies
+        word_level_timing_strategy = pseudo_word_level_strategies[word_level_timing_strategy]
+        keys_ = keys_ + ('start_time', 'end_time')
+
+    def get_words(s):
+        s = {
+            **s,
+            **{k: split_entry(s[k]) for k in keys}
+        }
+
+        if word_level_timing_strategy is not None:
+            # Add a dummy word so that empty segments are not removed
+            words = s['words'] or ['']
+            timestamps = word_level_timing_strategy(
+                (s['start_time'], s['end_time']),
+                words
+            )
+            s['start_time'] = [s for s, _ in timestamps]
+            s['end_time'] = [s for _, s in timestamps]
+
+        if segment_representation == 'word':
+            # Add an (empty) dummy word so that empty segments are not removed.
+            if not s['words']:
+                s['words'] = ['']
+
+            s = [
+                {
+                    **s,
+                    **dict(zip_strict(keys_, sp))
+                }
+                for sp in zip_strict(*[s[k] for k in keys_])
+            ]
+        else:
+            s = [s]
+
+        return s
+
+    d = d.flatmap(get_words)
+
+    if segment_representation == 'speaker':
+        if 'speaker' not in d.T.keys():
+            # Assume that all segments come from the same speaker
+            d = merge_segments(d, (), keys_)
+        else:
+            d = merge_segments(d, 'speaker', keys_)
+
+    return d
+
+
+def merge_segments(
+        d: SegLST,
+        merge_by: str | tuple[str],
+        merge_keys: tuple[str],
+        ignore_keys: tuple[str] = (),
+        strict: bool = False,
+):
+    """
+    Group segments by `merge_by` and merge segments.
+
+    >>> merge_segments(SegLST([{'a': 1, 'b': 2, 'c': 3}, {'a': 1, 'b': 3, 'c': 3}]), 'c', ('a', 'b'), ('c',))
+    SegLST(segments=[{'a': [1, 1], 'b': [2, 3]}])
+    >>> merge_segments(SegLST([{'a': 1, 'b': 2, 'c': 3}, {'a': 1, 'b': 3, 'c': 3}]), 'c', ('a', ), ('c',), strict=True)
+    Traceback (most recent call last):
+     ...
+    ValueError: Expected all values to be the same, but found [2, 3] for key b
+    >>> merge_segments(SegLST([{'a': [1, 2], 'b': 2, 'c': 3}, {'a': [3, 4], 'b': 3, 'c': 3}]), 'c', ('a', 'b'))
+    SegLST(segments=[{'a': [1, 2, 3, 4], 'b': [2, 3], 'c': 3}])
+    >>> merge_segments(SegLST([{'a': [1, 2], 'b': 2, 'c': 3}, {'a': [3, 4], 'b': 3, 'c': 3}]), ('b', 'c'), ('a', 'b'))
+    SegLST(segments=[{'a': [1, 2], 'b': [2], 'c': 3}, {'a': [3, 4], 'b': [3], 'c': 3}])
+    """
+
+    def merge(segments) -> meeteval.io.seglst.SegLstSegment:
+        """
+        Merges a group of segments. Concatenates entries in merge_keys
+        and drops keys in ignore_keys.
+
+        If strict is True, it raises an exception if any other keys
+        are not the same in all segments. Otherwise, drops any keys
+        that are not unique.
+        """
+        assert len(segments) > 0
+
+        # Only handle keys that are present in all segments
+        all_keys = set.intersection(*[set(s.keys()) for s in segments]) - set(ignore_keys)
+        all_keys = [k for k in segments[0] if k in all_keys]  # keep order
+
+        # collate
+        s = {
+            k: [s[k] for s in segments]
+            for k in all_keys
+        }
+
+        # Merge entries from merge_keys
+        for k in merge_keys:
+            # Concatenate iterables and keep a single list if
+            # all values are not iterable
+            try:
+                s[k] = [w for v in s[k] for w in v]
+            except TypeError:
+                pass
+
+        # Keep unique values, drop all others (or raise exception if strict=True)
+        for k in all_keys:
+            if k in merge_keys:
+                continue
+            if len(set(s[k])) == 1:
+                s[k] = s[k][0]
+            elif strict:
+                raise ValueError(
+                    f'Expected all values to be the same, but found '
+                    f'{s[k]} for key {k}'
+                )
+
+        return s
+
+    if isinstance(merge_by, str):
+        merge_by = (merge_by,)
+
+    groups = [d]
+    for key in merge_by:
+        groups = [
+            new_group
+            for group in groups
+            for new_group in group.groupby(key).values()
+        ]
+
+    d = SegLST([merge(g) for g in groups])
+    return d
 
 
 def words_to_int(*d: SegLST):
@@ -50,22 +198,18 @@ def words_to_int(*d: SegLST):
     words in d and assigning an integer to each word.
 
     >>> words_to_int(SegLST([{'words': 'a b c'}]))
-    [SegLST(segments=[{'words': 1}])]
+    [SegLST(segments=[{'words': 0}])]
 
     >>> words_to_int(SegLST([{'words': 'a'}, {'words': 'b'}]), SegLST([{'words': 'c'}, {'words': 'a'}]))
-    [SegLST(segments=[{'words': 4}, {'words': 2}]), SegLST(segments=[{'words': 3}, {'words': 4}])]
+    [SegLST(segments=[{'words': 0}, {'words': 1}]), SegLST(segments=[{'words': 2}, {'words': 0}])]
 
     TODO: use cython code for speedup
     TODO: unify everything. This stuff is done in multiple places in the code base.
     """
     # Convert into integer representation to save some computation later.
     # `'words'` contains a single word only.
-    sym2int = {v: i for i, v in enumerate([
-        segment['words']
-        for segment in itertools.chain(*d)
-        if segment['words']
-    ], start=1)}
-    sym2int[''] = 0
+    import collections
+    sym2int = collections.defaultdict(itertools.count().__next__)
 
     d = [d_.map(lambda s: {**s, 'words': sym2int[s['words']]}) for d_ in d]
     return d
@@ -81,55 +225,281 @@ def add_segment_index(d: SegLST):
     return d
 
 
-def preprocess(
-        reference, hypothesis,
-        segment_index='segment',
-        convert_to_int=False,
+def check_timestamps_valid(seglst: SegLST, name=None):
+    for s in seglst:
+        if s['end_time'] < s['start_time']:
+            raise ValueError(
+                f'The end time of an interval must be larger than the start '
+                f'time. Found {s} in {name}'
+            )
+
+
+def _select_keys(d: SegLST, keys=(), strict=True):
+    if strict:
+        return d.map(lambda x: {k: x[k] for k in keys})
+    else:
+        return d.map(lambda x: {k: x[k] for k in keys if k in x})
+
+
+def _preprocess_single(
+        segments: SegLST,
+        keep_keys=None,
+        sort='segment',
         remove_empty_segments=True,
+        word_level_timing_strategy=None,
+        name=None,
+        collar=0,
+        segment_index=False,  # 'segment', 'word', False
+        segment_representation='word',  # 'segment', 'word', 'speaker'
 ):
     """
-    Preprocessing for non-time-constrained WERs.
+    >>> from paderbox.utils.pretty import pprint
+    >>> segments = SegLST([{'words': 'c d', 'start_time': 1, 'end_time': 3}, {'words': 'a b', 'start_time': 0, 'end_time': 3}])
+    >>> _preprocess_single(segments, sort=True, word_level_timing_strategy='character_based', name='test')
+    Traceback (most recent call last):
+        ...
+    ValueError: The order of word-level timings contradicts the segment-level order in test: 2 of 4 times.
+    Consider setting sort to False or "segment" or "word".
+    >>> pprint(_preprocess_single(segments, sort=False, word_level_timing_strategy='character_based'))
+    (SegLST([{'words': 'c', 'start_time': 1.0, 'end_time': 2.0},
+             {'words': 'd', 'start_time': 2.0, 'end_time': 3.0},
+             {'words': 'a', 'start_time': 0.0, 'end_time': 1.5},
+             {'words': 'b', 'start_time': 1.5, 'end_time': 3.0}]),
+     SelfOverlap(overlap_rate=0.6666666666666666, overlap_time=2, total_time=3))
+    >>> pprint(_preprocess_single(segments, sort='segment', word_level_timing_strategy='character_based'))
+    (SegLST([{'words': 'a', 'start_time': 0.0, 'end_time': 1.5},
+             {'words': 'b', 'start_time': 1.5, 'end_time': 3.0},
+             {'words': 'c', 'start_time': 1.0, 'end_time': 2.0},
+             {'words': 'd', 'start_time': 2.0, 'end_time': 3.0}]),
+     SelfOverlap(overlap_rate=0.6666666666666666, overlap_time=2, total_time=3))
+    >>> pprint(_preprocess_single(segments, sort='word', word_level_timing_strategy='character_based'))
+    (SegLST([{'words': 'a', 'start_time': 0.0, 'end_time': 1.5},
+             {'words': 'c', 'start_time': 1.0, 'end_time': 2.0},
+             {'words': 'b', 'start_time': 1.5, 'end_time': 3.0},
+             {'words': 'd', 'start_time': 2.0, 'end_time': 3.0}]),
+     SelfOverlap(overlap_rate=0.6666666666666666, overlap_time=2, total_time=3))
+
+    >>> pprint(_preprocess_single(segments, sort='word', keep_keys=('words',)))
+    (SegLST([{'words': 'a'}, {'words': 'b'}, {'words': 'c'}, {'words': 'd'}]),
+     SelfOverlap(overlap_rate=0.6666666666666666, overlap_time=2, total_time=3))
     """
+    # Check if arguments are valid
     if segment_index not in ('segment', 'word', False):
         raise ValueError(segment_index)
 
+    contains_timestamps = (
+            len(segments) == 0
+            or 'start_time' in segments.T.keys()
+            and 'end_time' in segments.T.keys()
+    )
+    if sort not in (True, False, 'segment', 'word', 'maybe_segment'):
+        raise ValueError(
+            f'Invalid value for sort: {sort}. Choose one of True, False, '
+            f'"segment", "word"'
+        )
+    else:
+        if sort == 'maybe_segment':
+            if contains_timestamps:
+                sort = 'segment'
+            else:
+                logger.warning(
+                    f'Assuming sort=False because timestamps are '
+                    f'missing in {name}.'
+                )
+                sort = False
+        if sort == 'word' and segment_representation != 'word':
+            raise ValueError(
+                f'sort={sort} is only supported if segment_representation=\'word\'.'
+            )
+        if sort is not False and not contains_timestamps:
+            raise ValueError(
+                f'sort={sort} is only supported if the data contains timestamps.'
+            )
+
+    if segment_index == 'word' and segment_representation != 'word':
+        raise ValueError(
+            f'segment_index=\'word\' is only supported if segment_representation=\'word\'.'
+        )
+    if collar is not None and collar > 0:
+        if not contains_timestamps:
+            raise ValueError(
+                f'collar={collar} is only supported if the data contains timestamps.'
+            )
+        if keep_keys is not None and 'begin_time' not in keep_keys and 'end_time' not in keep_keys:
+            raise ValueError(
+                f'collar={collar} but keep_keys does not contain "begin_time" and "end_time", '
+                f'i.e. the timestamps are ignored'
+            )
+    if word_level_timing_strategy is not None and not contains_timestamps:
+        raise ValueError(
+            f'word_level_timing_strategy={word_level_timing_strategy} is only '
+            f'supported if the data contains timestamps.'
+        )
+
+    # Check if data is valid
+    if contains_timestamps:
+        check_timestamps_valid(segments, name)
+
+    # Compute self-overlap before anything else
+    if 'start_time' in segments.T.keys() and 'end_time' in segments.T.keys():
+        from meeteval.wer.wer.time_constrained import get_self_overlap
+        if 'speaker' in segments.T.keys():
+            self_overlap = sum(
+                [get_self_overlap(s) for s in segments.groupby('speaker').values()],
+                start=meeteval.wer.wer.time_constrained.SelfOverlap(0, 0)
+            )
+        else:
+            self_overlap = get_self_overlap(segments)
+    else:
+        self_overlap = None
+
+    # Add segment index
+    if segment_index == 'segment':
+        segments = add_segment_index(segments)
+
+    # Sort, if requested and timestamps are available
+    if sort in (True, 'segment', 'word') and contains_timestamps:
+        segments = segments.sorted('start_time')
+
+    # Remove keys that are not needed before duplicating them in the splitting
+    # process
+    if keep_keys is not None:
+        keep_keys = set(keep_keys)
+        if segment_index:
+            keep_keys.add('segment_index')
+        keep_keys1 = set(keep_keys)
+        keep_keys2 = set(keep_keys)
+        if contains_timestamps:
+            # Timestamps are needed later for the check of the order of the
+            # words matches
+            keep_keys1.update({'start_time', 'end_time'})
+        segments = _select_keys(segments, keep_keys1, strict=False)
+
+    # Split into words. After this, the 'words' key contains a list of words
+    # instead of a string
+    words = split_words(
+        segments,
+        word_level_timing_strategy=word_level_timing_strategy,
+        segment_representation=segment_representation
+    )
+
+    # Warn or raise an exception if the order of the words contradicts the
+    # order of the segments.
+    if contains_timestamps:
+
+        # Check order for every speaker individually
+        if 'speaker' in segments.T.keys():
+            grouped_words = words.groupby('speaker')
+        else:
+            grouped_words = {None: words}
+
+        if segment_representation != 'word':
+            words_ = split_words(
+                segments,
+                word_level_timing_strategy=word_level_timing_strategy,
+                segment_representation='word'
+            )
+            if 'speaker' in segments.T.keys():
+                grouped_words_ = words_.groupby('speaker')
+            else:
+                grouped_words_ = {None: words_}
+        else:
+            grouped_words_ = grouped_words
+
+        for speaker, spk_words in grouped_words.items():
+            words_ = grouped_words_[speaker]
+
+            words_sorted = words_.sorted('start_time')
+            if words_sorted != words_:
+                # This check should be fast because `sorted` doesn't change the identity
+                # of the contained objects (so `words_sorted[0] is words[0] == True`
+                # when they are sorted).
+                contradictions = [a != b for a, b in zip(words_sorted, words_)]
+                try:
+                    session_ids = f' (session ids: {sorted(set(segments.T["session_id"]))})'
+                except KeyError:
+                    session_ids = ''
+                if speaker is None:
+                    speaker = ''
+                else:
+                    speaker = f' for speaker {speaker}'
+                msg = (
+                    f'The order of word-level timings contradicts the segment-level '
+                    f'order in {name}{speaker}: '
+                    f'{sum(contradictions)} of {len(contradictions)} times.'
+                    f'{session_ids}'
+                )
+                if sort is not True:
+                    logger.warning(msg)
+                else:
+                    raise ValueError(
+                        f'{msg}\nConsider setting sort to False or "segment" or "word".'
+                    )
+
+        # Sort again here, this time across speakers
+        if sort == 'word':
+            words = words.sorted('start_time')
+
+    if segment_index == 'word':
+        words = add_segment_index(words)
+
+    if remove_empty_segments:
+        words = words.filter(lambda s: s['words'])
+
+    if collar is not None and collar > 0:
+        from meeteval.wer.wer.time_constrained import apply_collar
+        words = apply_collar(words, collar)
+
+    if keep_keys is not None and keep_keys1 != keep_keys2:
+        words = _select_keys(words, keep_keys2)
+
+    return words, self_overlap
+
+
+def preprocess(
+        reference, hypothesis,
+        keep_keys=None, # None or tuple[str]
+        segment_index='segment',
+        convert_to_int=False,
+        remove_empty_segments=True,
+        reference_sort='segment',
+        hypothesis_sort='segment',
+        collar=None,
+        reference_pseudo_word_level_timing=None,
+        hypothesis_pseudo_word_level_timing=None,
+        segment_representation='segment',  # 'segment', 'word', 'speaker'
+):
+    """
+    Preprocessing.
+    """
     # Convert before calling this function if special parameters are required
     reference = meeteval.io.asseglst(reference)
     hypothesis = meeteval.io.asseglst(hypothesis)
 
     check_single_filename(reference, hypothesis)
 
-    if 'begin_time' in reference.T.keys() and 'end_time' in reference.T.keys():
-        from meeteval.wer.wer.time_constrained import get_self_overlap
-        reference_self_overlap = get_self_overlap(reference)
-        if reference_self_overlap.total_time == 0:
-            reference_self_overlap = None
-    else:
-        reference_self_overlap = None
+    reference, reference_self_overlap = _preprocess_single(
+        reference,
+        segment_index=segment_index,
+        remove_empty_segments=remove_empty_segments,
+        sort=reference_sort,
+        name='reference',
+        word_level_timing_strategy=reference_pseudo_word_level_timing,
+        segment_representation=segment_representation,
+    )
+    hypothesis, hypothesis_self_overlap = _preprocess_single(
+        hypothesis,
+        segment_index=segment_index,
+        remove_empty_segments=remove_empty_segments,
+        sort=hypothesis_sort,
+        name='hypothesis',
+        collar=collar,
+        word_level_timing_strategy=hypothesis_pseudo_word_level_timing,
+        segment_representation=segment_representation,
+    )
 
-    if 'begin_time' in hypothesis.T.keys() and 'end_time' in hypothesis.T.keys():
-        from meeteval.wer.wer.time_constrained import get_self_overlap
-        hypothesis_self_overlap = get_self_overlap(hypothesis)
-        if hypothesis_self_overlap.total_time == 0:
-            hypothesis_self_overlap = None
-    else:
-        hypothesis_self_overlap = None
-
-    if segment_index == 'segment':
-        reference = add_segment_index(reference)
-        hypothesis = add_segment_index(hypothesis)
-
-    reference = split_words(reference)
-    hypothesis = split_words(hypothesis)
-
-    if segment_index == 'word':
-        reference = add_segment_index(reference)
-        hypothesis = add_segment_index(hypothesis)
-
-    if remove_empty_segments:
-        reference = reference.filter(lambda s: s['words'])
-        hypothesis = hypothesis.filter(lambda s: s['words'])
-
+    # Conversion to integer must be done across reference and hypothesis
+    # for a consistent mapping.
     if convert_to_int:
         reference, hypothesis = words_to_int(reference, hypothesis)
 

--- a/meeteval/wer/preprocess.py
+++ b/meeteval/wer/preprocess.py
@@ -1,0 +1,131 @@
+import itertools
+
+import meeteval
+from meeteval.io import SegLST
+from meeteval.io.seglst import seglst_map
+from meeteval.wer.wer.utils import check_single_filename
+
+
+@seglst_map()
+def split_words(
+        d: 'SegLST',
+        *,
+        keys=('words',)
+):
+    """
+    Splits segments into words and copies all other entries.
+
+    Uses a word-level timing strategy to convert the segment-level timings
+    into word-level timings. If no strategy is given, the timings are
+    copied as they are.
+
+    >>> split_words(SegLST([{'words': 'a b c'}]))
+    SegLST(segments=[{'words': 'a'}, {'words': 'b'}, {'words': 'c'}])
+
+    >>> split_words(SegLST([{'words': 'a b c', 'start_time': 0, 'end_time': 1}]))
+    SegLST(segments=[{'words': 'a', 'start_time': 0, 'end_time': 1}, {'words': 'b', 'start_time': 0, 'end_time': 1}, {'words': 'c', 'start_time': 0, 'end_time': 1}])
+
+    >>> split_words(SegLST([{'words': 'a b c', 'word_timings': [(0, 1), (1, 2), (2, 3)]}]), keys=('words', 'word_timings'))
+    SegLST(segments=[{'words': 'a', 'word_timings': (0, 1)}, {'words': 'b', 'word_timings': (1, 2)}, {'words': 'c', 'word_timings': (2, 3)}])
+    """
+    def split_entry(x):
+        if isinstance(x, str):
+            return x.split() or ['']
+        elif isinstance(x, (list, tuple)):
+            return x
+        else:
+            raise TypeError(x)
+
+    return d.flatmap(
+        lambda s: [
+            {**s, **dict(zip(keys, split, strict=True))}
+            for split in zip(*(split_entry(s[key]) for key in keys))
+        ])
+
+
+def words_to_int(*d: SegLST):
+    """
+    Converts all words to ints. The mapping is created by iterating over all
+    words in d and assigning an integer to each word.
+
+    >>> words_to_int(SegLST([{'words': 'a b c'}]))
+    [SegLST(segments=[{'words': 1}])]
+
+    >>> words_to_int(SegLST([{'words': 'a'}, {'words': 'b'}]), SegLST([{'words': 'c'}, {'words': 'a'}]))
+    [SegLST(segments=[{'words': 4}, {'words': 2}]), SegLST(segments=[{'words': 3}, {'words': 4}])]
+
+    TODO: use cython code for speedup
+    TODO: unify everything. This stuff is done in multiple places in the code base.
+    """
+    # Convert into integer representation to save some computation later.
+    # `'words'` contains a single word only.
+    sym2int = {v: i for i, v in enumerate([
+        segment['words']
+        for segment in itertools.chain(*d)
+        if segment['words']
+    ], start=1)}
+    sym2int[''] = 0
+
+    d = [d_.map(lambda s: {**s, 'words': sym2int[s['words']]}) for d_ in d]
+    return d
+
+
+def add_segment_index(d: SegLST):
+    """
+    Adds a segment index to the segments, if not already present.
+    """
+    if 'segment_index' not in d.T.keys():
+        counter = itertools.count()
+        d = d.map(lambda x: {**x, 'segment_index': next(counter)})
+    return d
+
+
+def preprocess(
+        reference, hypothesis,
+        segment_index='segment',
+        convert_to_int=True,
+        remove_empty_segments=True,
+):
+    """
+    Preprocessing for non-time-constrained WERs.
+    """
+    if segment_index not in ('segment', 'word', False):
+        raise ValueError(segment_index)
+
+    # Convert before calling this function if special parameters are required
+    reference = meeteval.io.asseglst(reference)
+    hypothesis = meeteval.io.asseglst(hypothesis)
+
+    check_single_filename(reference, hypothesis)
+
+    if 'begin_time' in reference.T.keys() and 'end_time' in reference.T.keys():
+        from meeteval.wer.wer.time_constrained import get_self_overlap
+        reference_self_overlap = get_self_overlap(reference)
+    else:
+        reference_self_overlap = None
+
+    if 'begin_time' in hypothesis.T.keys() and 'end_time' in hypothesis.T.keys():
+        from meeteval.wer.wer.time_constrained import get_self_overlap
+        hypothesis_self_overlap = get_self_overlap(hypothesis)
+    else:
+        hypothesis_self_overlap = None
+
+    if segment_index == 'segment':
+        reference = add_segment_index(reference)
+        hypothesis = add_segment_index(hypothesis)
+
+    reference = split_words(reference)
+    hypothesis = split_words(hypothesis)
+
+    if segment_index == 'word':
+        reference = add_segment_index(reference)
+        hypothesis = add_segment_index(hypothesis)
+
+    if remove_empty_segments:
+        reference = reference.filter(lambda s: s['words'])
+        hypothesis = hypothesis.filter(lambda s: s['words'])
+
+    if convert_to_int:
+        reference, hypothesis = words_to_int(reference, hypothesis)
+
+    return reference, hypothesis, reference_self_overlap, hypothesis_self_overlap

--- a/meeteval/wer/preprocess.py
+++ b/meeteval/wer/preprocess.py
@@ -292,13 +292,13 @@ def _preprocess_single(
             or 'start_time' in segments.T.keys()
             and 'end_time' in segments.T.keys()
     )
-    if sort not in (True, False, 'segment', 'word', 'maybe_segment'):
+    if sort not in (True, False, 'segment', 'word', 'segment_if_available'):
         raise ValueError(
             f'Invalid value for sort: {sort}. Choose one of True, False, '
             f'"segment", "word"'
         )
     else:
-        if sort == 'maybe_segment':
+        if sort == 'segment_if_available':
             if contains_timestamps:
                 sort = 'segment'
             else:

--- a/meeteval/wer/preprocess.py
+++ b/meeteval/wer/preprocess.py
@@ -2,6 +2,7 @@ import itertools
 
 import meeteval
 from meeteval.io import SegLST
+from meeteval.io.pbjson import zip_strict
 from meeteval.io.seglst import seglst_map
 from meeteval.wer.wer.utils import check_single_filename
 
@@ -38,8 +39,8 @@ def split_words(
 
     return d.flatmap(
         lambda s: [
-            {**s, **dict(zip(keys, split, strict=True))}
-            for split in zip(*(split_entry(s[key]) for key in keys))
+            {**s, **dict(zip_strict(keys, split))}
+            for split in zip_strict(*(split_entry(s[key]) for key in keys))
         ])
 
 

--- a/meeteval/wer/wer/cp.py
+++ b/meeteval/wer/wer/cp.py
@@ -107,17 +107,12 @@ class CPErrorRate(ErrorRate):
         )
 
 
-def cp_error_rate(reference: 'SegLST', hypothesis: 'SegLST') -> CPErrorRate:
-    from meeteval.wer.wer.siso import _seglst_siso_error_rate, siso_levenshtein_distance
-    return _cp_error_rate(
-        reference,
-        hypothesis,
-        distance_fn=siso_levenshtein_distance,
-        siso_error_rate=_seglst_siso_error_rate,
-    )
-
-
-def cp_word_error_rate(reference: 'SegLST', hypothesis: 'SegLST') -> CPErrorRate:
+def cp_word_error_rate(
+        reference: 'SegLST',
+        hypothesis: 'SegLST',
+        reference_sort='maybe_segment',
+        hypothesis_sort='maybe_segment',
+) -> CPErrorRate:
     """
     The Concatenated minimum Permutation WER (cpWER).
 
@@ -150,6 +145,7 @@ def cp_word_error_rate(reference: 'SegLST', hypothesis: 'SegLST') -> CPErrorRate
     >>> cp_word_error_rate({'r0': 'a b'}, {'h0': 'z', 'h1': 'a e f'})  # Special case for overestimation, that was buggy in the past.
     CPErrorRate(error_rate=1.5, errors=3, length=2, insertions=2, deletions=0, substitutions=1, missed_speaker=0, falarm_speaker=1, scored_speaker=1, assignment=(('r0', 'h1'), (None, 'h0')))
 
+    Whitespace is ignored
     >>> cp_word_error_rate({'r0': 'a b', 'r1': 'k'}, {'h0': ' ', 'h1': 'a e f'})  # Special case for overestimation, that was buggy in the past.
     CPErrorRate(error_rate=1.0, errors=3, length=3, insertions=1, deletions=1, substitutions=1, missed_speaker=0, falarm_speaker=0, scored_speaker=2, assignment=(('r0', 'h1'), ('r1', 'h0')))
 
@@ -157,7 +153,7 @@ def cp_word_error_rate(reference: 'SegLST', hypothesis: 'SegLST') -> CPErrorRate
     >>> r = STM([STMLine.parse('file1 0 r0 0 1 Hello World')])
     >>> h = STM([STMLine.parse('file1 0 h0 0 1 Hello World')])
     >>> cp_word_error_rate(r, h)
-    CPErrorRate(error_rate=0.0, errors=0, length=2, insertions=0, deletions=0, substitutions=0, missed_speaker=0, falarm_speaker=0, scored_speaker=1, assignment=(('r0', 'h0'),))
+    CPErrorRate(error_rate=0.0, errors=0, length=2, insertions=0, deletions=0, substitutions=0, reference_self_overlap=SelfOverlap(overlap_rate=Decimal('0'), overlap_time=0, total_time=Decimal('1')), hypothesis_self_overlap=SelfOverlap(overlap_rate=Decimal('0'), overlap_time=0, total_time=Decimal('1')), missed_speaker=0, falarm_speaker=0, scored_speaker=1, assignment=(('r0', 'h0'),))
 
     >>> cp_word_error_rate(['a b c'.split(), 'd e f'.split()], ['a b c'.split(), 'd e f'.split()])
     CPErrorRate(error_rate=0.0, errors=0, length=6, insertions=0, deletions=0, substitutions=0, missed_speaker=0, falarm_speaker=0, scored_speaker=2, assignment=((0, 0), (1, 1)))
@@ -167,11 +163,25 @@ def cp_word_error_rate(reference: 'SegLST', hypothesis: 'SegLST') -> CPErrorRate
     hypothesis = asseglst(hypothesis, required_keys=('speaker', 'words'))
     reference, hypothesis, ref_self_overlap, hyp_self_overlap = preprocess(
         reference, hypothesis,
+        keep_keys=('speaker', 'words'),
         remove_empty_segments=False,
+        reference_sort=reference_sort,
+        hypothesis_sort=hypothesis_sort,
+        segment_representation='segment',
+    )
+
+    from meeteval.wer.wer.siso import _siso_error_rate
+    from meeteval.wer.matching.cy_levenshtein import levenshtein_distance
+
+    error_rate = _minimum_permutation_word_error_rate(
+        {k: [w for words in v.T['words'] for w in words] for k, v in reference.groupby('speaker').items()},
+        {k: [w for words in v.T['words'] for w in words] for k, v in hypothesis.groupby('speaker').items()},
+        distance_fn=levenshtein_distance,
+        siso_error_rate=_siso_error_rate,
     )
 
     return dataclasses.replace(
-        cp_error_rate(reference, hypothesis),
+        error_rate,
         reference_self_overlap=ref_self_overlap,
         hypothesis_self_overlap=hyp_self_overlap,
     )
@@ -189,18 +199,28 @@ def cp_word_error_rate_multifile(
     return apply_multi_file(cp_word_error_rate, reference, hypothesis, partial=partial)
 
 
-def _get_cp_assignment(
-        reference: SegLST,
-        hypothesis: SegLST,
+def _minimum_permutation_assignment(
+        reference: dict[str, SegLST],
+        hypothesis: dict[str, SegLST],
         distance_fn: callable,
-):
+        missing=SegLST([])
+) -> (tuple[int], int):
+    """
+    Compute the best (lowest distance) assignment of reference and hypothesis
+    speakers based on `distance_fn`.
+
+    Returns:
+        The assignment and the distance
+
+    >>> _minimum_permutation_assignment({}, {}, lambda x, y: 0)
+    ((), 0)
+    >>> _minimum_permutation_assignment({}, {'spkA': meeteval.io.SegLST([])}, lambda x, y: 1)
+    (((None, 'spkA'),), 1)
+    >>> _minimum_permutation_assignment({'spkA': meeteval.io.SegLST([])}, {}, lambda x, y: 1)
+    ((('spkA', None),), 1)
+    """
     import scipy.optimize
     import numpy as np
-
-    if isinstance(reference, SegLST):
-        reference = reference.groupby('speaker')
-    if isinstance(hypothesis, SegLST):
-        hypothesis = hypothesis.groupby('speaker')
 
     cost_matrix = np.array([
         [
@@ -208,15 +228,18 @@ def _get_cp_assignment(
             for et, _ in itertools.zip_longest(
             hypothesis.values(),
             reference.values(),  # ignored, "padding" for underestimation
-            fillvalue=SegLST([]),
+            fillvalue=missing,
         )
         ]
         for tt, _ in itertools.zip_longest(
             reference.values(),
             hypothesis.values(),  # ignored, "padding" for overestimation
-            fillvalue=SegLST([]),
+            fillvalue=missing,
         )
     ])
+
+    if cost_matrix.size == 0:
+        return (), 0
 
     # Find the best permutation with hungarian algorithm
     row_ind, col_ind = scipy.optimize.linear_sum_assignment(cost_matrix)
@@ -237,21 +260,25 @@ def _get_cp_assignment(
     return assignment, distance
 
 
-def _cp_error_rate(
-        reference: SegLST,
-        hypothesis: SegLST,
+def _minimum_permutation_word_error_rate(
+        reference: dict,
+        hypothesis: dict,
         distance_fn: callable,
         siso_error_rate: callable,
-):
-    # Used in
-    #   cp_word_error_rate
-    # and
-    #   time_constrained_minimum_permutation_word_error_rate
-    # .
+        missing=SegLST([]),
+) -> CPErrorRate:
+    """
+    Computes the WER for the best (minimum error rate) assignment of reference
+    to hypothesis speakers.
 
-    reference = reference.groupby('speaker')
-    hypothesis = hypothesis.groupby('speaker')
+    Statistics (insertions, deletions, ...) are copied from the output of
+    `siso_error_rate` after resolving the assignment.
 
+    Performs no preprocessing. This means:
+    - reference and hypothesis must be dicts of SegLSTs matching the input
+        format of `distance_fn` and `siso_error_rate`
+    - no self-overlap is computed
+    """
     if max(len(hypothesis), len(reference)) > 20:
         num_speakers = max(len(hypothesis), len(reference))
         raise RuntimeError(
@@ -264,22 +291,27 @@ def _cp_error_rate(
             f'for details.'
         )
 
-    assignment, distance = _get_cp_assignment(reference, hypothesis, distance_fn)
+    assignment, distance = _minimum_permutation_assignment(
+        reference, hypothesis, distance_fn, missing
+    )
 
     missed_speaker = max(0, len(reference) - len(hypothesis))
     falarm_speaker = max(0, len(hypothesis) - len(reference))
 
-    reference_new, hypothesis_new = apply_cp_assignment(
-        assignment,
-        reference=reference,
-        hypothesis=hypothesis,
-        missing=SegLST([]),
-    )
+    if assignment:
+        reference_new, hypothesis_new = apply_cp_assignment(
+            assignment,
+            reference=reference,
+            hypothesis=hypothesis,
+            missing=missing,
+        )
+    else:
+        reference_new, hypothesis_new = reference, hypothesis
 
     er = sum([
         siso_error_rate(r, hypothesis_new[speaker])
         for speaker, r in reference_new.items()
-    ])
+    ], start=ErrorRate.zero())
 
     assert distance == er.errors, (distance, er)
 

--- a/meeteval/wer/wer/cp.py
+++ b/meeteval/wer/wer/cp.py
@@ -220,7 +220,7 @@ def _minimum_permutation_assignment(
         hypothesis: 'dict[str, T]',
         distance_fn: 'callable[[T, T], int]',
         missing: 'T' = SegLST([])
-) -> (tuple[int], int):
+) -> '(tuple[int], int)':
     """
     Compute the best (lowest distance) assignment of reference and hypothesis
     speakers based on `distance_fn`.
@@ -277,11 +277,11 @@ def _minimum_permutation_assignment(
 
 
 def _minimum_permutation_word_error_rate(
-        reference: dict,
-        hypothesis: dict,
-        distance_fn: callable,
-        siso_error_rate: callable,
-        missing=SegLST([]),
+        reference: 'dict[str, T]',
+        hypothesis: 'dict[str, T]',
+        distance_fn: 'callable[[T, T], int]',
+        siso_error_rate: 'callable[[T, T], ErrorRate]',
+        missing: 'T' = SegLST([]),
 ) -> CPErrorRate:
     """
     Computes the WER for the best (minimum error rate) assignment of reference

--- a/meeteval/wer/wer/cp.py
+++ b/meeteval/wer/wer/cp.py
@@ -2,7 +2,7 @@ import dataclasses
 import functools
 import itertools
 import string
-from typing import Optional, Any, Iterable
+import typing
 
 import meeteval
 from meeteval._typing import Literal
@@ -10,6 +10,11 @@ from meeteval.io.seglst import SegLST, asseglst, asseglistconvertible
 from meeteval.wer.preprocess import preprocess
 
 from meeteval.wer.wer.error_rate import ErrorRate
+
+if typing.TYPE_CHECKING:
+    T = typing.TypeVar('T')
+    from typing import Optional, Any
+
 
 __all__ = [
     'CPErrorRate',
@@ -211,10 +216,10 @@ def cp_word_error_rate_multifile(
 
 
 def _minimum_permutation_assignment(
-        reference: dict[str, SegLST],
-        hypothesis: dict[str, SegLST],
-        distance_fn: callable,
-        missing=SegLST([])
+        reference: 'dict[str, T]',
+        hypothesis: 'dict[str, T]',
+        distance_fn: 'callable[[T, T], int]',
+        missing: 'T' = SegLST([])
 ) -> (tuple[int], int):
     """
     Compute the best (lowest distance) assignment of reference and hypothesis

--- a/meeteval/wer/wer/cp.py
+++ b/meeteval/wer/wer/cp.py
@@ -1,4 +1,5 @@
 import dataclasses
+import functools
 import itertools
 import string
 from typing import Optional, Any, Iterable
@@ -188,7 +189,9 @@ def cp_word_error_rate(
 
 
 def cp_word_error_rate_multifile(
-        reference, hypothesis, partial=False
+        reference, hypothesis, partial=False,
+        reference_sort='maybe_segment',
+        hypothesis_sort='maybe_segment',
 ) -> 'dict[str, CPErrorRate]':
     """
     Computes the cpWER for each example in the reference and hypothesis STM files.
@@ -196,7 +199,15 @@ def cp_word_error_rate_multifile(
     To compute the overall WER, use `sum(cp_word_error_rate_multifile(r, h).values())`.
     """
     from meeteval.io.seglst import apply_multi_file
-    return apply_multi_file(cp_word_error_rate, reference, hypothesis, partial=partial)
+    return apply_multi_file(
+        functools.partial(
+            cp_word_error_rate,
+            reference_sort=reference_sort,
+            hypothesis_sort=hypothesis_sort,
+        ),
+        reference, hypothesis,
+        partial=partial
+    )
 
 
 def _minimum_permutation_assignment(

--- a/meeteval/wer/wer/cp.py
+++ b/meeteval/wer/wer/cp.py
@@ -273,7 +273,7 @@ def _minimum_permutation_assignment(
         (reference_keys.get(r), hypothesis_keys.get(c))
         for r, c in itertools.zip_longest(row_ind, col_ind)
     ])
-    return assignment, distance
+    return assignment, int(distance)
 
 
 def _minimum_permutation_word_error_rate(

--- a/meeteval/wer/wer/cp.py
+++ b/meeteval/wer/wer/cp.py
@@ -116,8 +116,8 @@ class CPErrorRate(ErrorRate):
 def cp_word_error_rate(
         reference: 'SegLST',
         hypothesis: 'SegLST',
-        reference_sort='maybe_segment',
-        hypothesis_sort='maybe_segment',
+        reference_sort='segment_if_available',
+        hypothesis_sort='segment_if_available',
 ) -> CPErrorRate:
     """
     The Concatenated minimum Permutation WER (cpWER).
@@ -195,8 +195,8 @@ def cp_word_error_rate(
 
 def cp_word_error_rate_multifile(
         reference, hypothesis, partial=False,
-        reference_sort='maybe_segment',
-        hypothesis_sort='maybe_segment',
+        reference_sort='segment_if_available',
+        hypothesis_sort='segment_if_available',
 ) -> 'dict[str, CPErrorRate]':
     """
     Computes the cpWER for each example in the reference and hypothesis STM files.

--- a/meeteval/wer/wer/mimo.py
+++ b/meeteval/wer/wer/mimo.py
@@ -78,7 +78,12 @@ def mimo_error_rate(
     )
 
 
-def mimo_word_error_rate(reference, hypothesis) -> MimoErrorRate:
+def mimo_word_error_rate(
+        reference,
+        hypothesis,
+        reference_sort='maybe_segment',
+        hypothesis_sort='maybe_segment',
+) -> MimoErrorRate:
     """
     The Multiple Input speaker, Multiple Output channel (MIMO) WER.
 
@@ -98,23 +103,25 @@ def mimo_word_error_rate(reference, hypothesis) -> MimoErrorRate:
     MimoErrorRate(error_rate=0.0, errors=0, length=6, insertions=0, deletions=0, substitutions=0, assignment=[('A', 'O2'), ('B', 'O2'), ('A', 'O1')])
 
     >>> mimo_word_error_rate(STM.parse('X 1 A 0.0 1.0 a b\\nX 1 A 1.0 2.0 c d\\nX 1 B 0.0 2.0 e f\\n'), STM.parse('X 1 1 0.0 2.0 c d\\nX 1 0 0.0 2.0 a b e f\\n'))
-    MimoErrorRate(error_rate=0.0, errors=0, length=6, insertions=0, deletions=0, substitutions=0, assignment=[('A', '0'), ('B', '0'), ('A', '1')])
+    MimoErrorRate(error_rate=0.0, errors=0, length=6, insertions=0, deletions=0, substitutions=0, reference_self_overlap=SelfOverlap(overlap_rate=Decimal('0E+1'), overlap_time=0, total_time=Decimal('4.0')), hypothesis_self_overlap=SelfOverlap(overlap_rate=Decimal('0E+1'), overlap_time=0, total_time=Decimal('4.0')), assignment=[('A', '0'), ('B', '0'), ('A', '1')])
     """
     reference, hypothesis, ref_self_overlap, hyp_self_overlap = preprocess(
         reference, hypothesis,
         remove_empty_segments=False,
+        reference_sort=reference_sort,
+        hypothesis_sort=hypothesis_sort,
     )
 
     # Convert to dict of lists of words and remove empty words here.
     reference = {
         k: [
-            [word for word in segment.T['words'] if word != '']
+            [word for words in segment.T['words'] for word in words if word != '']
             for segment in v.groupby('segment_index').values()
         ]
         for k, v in reference.groupby('speaker').items()
     }
     hypothesis = {
-        k: [word for word in v.T['words'] if word != '']
+        k: [word for words in v.T['words'] for word in words if word != '']
         for k, v in hypothesis.groupby('speaker').items()
     }
 

--- a/meeteval/wer/wer/mimo.py
+++ b/meeteval/wer/wer/mimo.py
@@ -102,13 +102,6 @@ def mimo_word_error_rate(reference, hypothesis) -> MimoErrorRate:
     reference = asseglst(reference)
     hypothesis = asseglst(hypothesis)
 
-    # Sort by start time if the start time is available
-    # TODO: implement something like reference_sort from time_constrained.py?
-    if 'start_time' in reference.T.keys():
-        reference = reference.sorted('start_time')
-    if 'start_time' in hypothesis.T.keys():
-        hypothesis = hypothesis.sorted('start_time')
-
     # Convert to dict of lists of words
     reference = {
         k: [s['words'].split() for s in v if s['words'] != '']

--- a/meeteval/wer/wer/mimo.py
+++ b/meeteval/wer/wer/mimo.py
@@ -82,8 +82,8 @@ def mimo_error_rate(
 def mimo_word_error_rate(
         reference,
         hypothesis,
-        reference_sort='maybe_segment',
-        hypothesis_sort='maybe_segment',
+        reference_sort='segment_if_available',
+        hypothesis_sort='segment_if_available',
 ) -> MimoErrorRate:
     """
     The Multiple Input speaker, Multiple Output channel (MIMO) WER.
@@ -138,8 +138,8 @@ def mimo_word_error_rate_multifile(
         reference,
         hypothesis,
         partial=False,
-        reference_sort='maybe_segment',
-        hypothesis_sort='maybe_segment',
+        reference_sort='segment_if_available',
+        hypothesis_sort='segment_if_available',
 ) -> 'dict[str, MimoErrorRate]':
     """
     Computes the MIMO WER for each example in the reference and hypothesis

--- a/meeteval/wer/wer/mimo.py
+++ b/meeteval/wer/wer/mimo.py
@@ -1,4 +1,5 @@
 import dataclasses
+import functools
 from typing import Iterable, Any
 
 from meeteval.io.seglst import asseglistconvertible
@@ -137,6 +138,8 @@ def mimo_word_error_rate_multifile(
         reference,
         hypothesis,
         partial=False,
+        reference_sort='maybe_segment',
+        hypothesis_sort='maybe_segment',
 ) -> 'dict[str, MimoErrorRate]':
     """
     Computes the MIMO WER for each example in the reference and hypothesis
@@ -146,7 +149,14 @@ def mimo_word_error_rate_multifile(
     `sum(mimo_word_error_rate_multifile(r, h).values())`.
     """
     from meeteval.io.seglst import apply_multi_file
-    return apply_multi_file(mimo_word_error_rate, reference, hypothesis, partial=partial)
+    return apply_multi_file(
+        functools.partial(
+            mimo_word_error_rate,
+            reference_sort=reference_sort,
+            hypothesis_sort=hypothesis_sort,
+        ),
+        reference, hypothesis, partial=partial
+    )
 
 
 def apply_mimo_assignment(

--- a/meeteval/wer/wer/orc.py
+++ b/meeteval/wer/wer/orc.py
@@ -1,4 +1,5 @@
 import dataclasses
+import typing
 
 import meeteval
 from meeteval.io.py import NestedStructure
@@ -16,6 +17,9 @@ __all__ = [
 ]
 
 from meeteval.wer.preprocess import preprocess
+
+if typing.TYPE_CHECKING:
+    from meeteval.io.seglst import SegLST
 
 
 @dataclasses.dataclass(frozen=True, repr=False)

--- a/meeteval/wer/wer/orc.py
+++ b/meeteval/wer/wer/orc.py
@@ -1,4 +1,5 @@
 import dataclasses
+import functools
 import typing
 
 import meeteval
@@ -56,6 +57,8 @@ def orc_word_error_rate_multifile(
         reference,
         hypothesis,
         partial=False,
+        reference_sort='maybe_segment',
+        hypothesis_sort='maybe_segment',
 ) -> 'dict[str, OrcErrorRate]':
     """
     Computes the ORC WER for each example in the reference and hypothesis files.
@@ -65,7 +68,11 @@ def orc_word_error_rate_multifile(
     """
     from meeteval.io.seglst import apply_multi_file
     return apply_multi_file(
-        orc_word_error_rate, reference, hypothesis,
+        functools.partial(
+            orc_word_error_rate,
+            reference_sort=reference_sort,
+            hypothesis_sort=hypothesis_sort,
+        ), reference, hypothesis,
         partial=partial
     )
 

--- a/meeteval/wer/wer/orc.py
+++ b/meeteval/wer/wer/orc.py
@@ -57,8 +57,8 @@ def orc_word_error_rate_multifile(
         reference,
         hypothesis,
         partial=False,
-        reference_sort='maybe_segment',
-        hypothesis_sort='maybe_segment',
+        reference_sort='segment_if_available',
+        hypothesis_sort='segment_if_available',
 ) -> 'dict[str, OrcErrorRate]':
     """
     Computes the ORC WER for each example in the reference and hypothesis files.
@@ -151,8 +151,8 @@ def _orc_error_rate(
 def orc_word_error_rate(
         reference,
         hypothesis,
-        reference_sort='maybe_segment',
-        hypothesis_sort='maybe_segment',
+        reference_sort='segment_if_available',
+        hypothesis_sort='segment_if_available',
 ):
     """
     The Optimal Reference Combination (ORC) WER, implemented efficiently.

--- a/meeteval/wer/wer/siso.py
+++ b/meeteval/wer/wer/siso.py
@@ -2,6 +2,7 @@ import typing
 from typing import Hashable
 
 from meeteval.io.py import NestedStructure
+from meeteval.wer.preprocess import split_words
 from meeteval.wer.wer.error_rate import ErrorRate
 from meeteval.wer.wer.utils import kaldialign_edit_distance
 from meeteval.io.seglst import asseglst
@@ -115,13 +116,6 @@ def siso_word_error_rate(reference: 'SegLST', hypothesis: 'SegLST') -> ErrorRate
         raise ValueError(f'Reference must contain exactly one line, but found {len(reference)} lines.')
     if len(hypothesis) != 1:
         raise ValueError(f'Hypothesis must contain exactly one line, but found {len(hypothesis)} lines.')
-
-    def split_words(d):
-        return [
-            {**s, 'words': w}
-            for s in d
-            for w in (s['words'].split() if s['words'].strip() else [''])
-        ]
 
     return siso_error_rate(split_words(reference), split_words(hypothesis))
 

--- a/meeteval/wer/wer/time_constrained.py
+++ b/meeteval/wer/wer/time_constrained.py
@@ -5,9 +5,10 @@ import itertools
 import typing
 from dataclasses import dataclass, replace
 
+from meeteval.io.pbjson import zip_strict
 from meeteval.io.stm import STM
 from meeteval.io.seglst import SegLST, seglst_map, asseglst, SegLstSegment
-from meeteval.wer.preprocess import split_words, words_to_int
+from meeteval.wer.preprocess import split_words, words_to_int, add_segment_index, preprocess
 from meeteval.wer.wer.error_rate import ErrorRate, SelfOverlap
 from meeteval.wer.wer.cp import CPErrorRate
 import logging
@@ -163,9 +164,9 @@ def _time_constrained_siso_error_rate(
     reference = reference.filter(lambda s: s['words'])
     hypothesis = hypothesis.filter(lambda s: s['words'])
     reference_words = reference.T['words']
-    reference_timing = list(zip(reference.T['start_time'], reference.T['end_time']))
+    reference_timing = reference.T['start_time', 'end_time']
     hypothesis_words = hypothesis.T['words']
-    hypothesis_timing = list(zip(hypothesis.T['start_time'], hypothesis.T['end_time']))
+    hypothesis_timing = hypothesis.T['start_time', 'end_time']
 
     result = time_constrained_levenshtein_distance_with_alignment(
         reference_words, hypothesis_words, reference_timing, hypothesis_timing,
@@ -346,7 +347,13 @@ def apply_collar(s: SegLST, collar: float):
     X 1 A -1 2 a b
     <BLANKLINE>
     """
-    return s.map(lambda s: {**s, 'start_time': s['start_time'] - collar, 'end_time': s['end_time'] + collar})
+    return s.map(
+        lambda s: {
+            **s,
+            'start_time': [t - collar for t in s['start_time']] if isinstance(s['start_time'], list) else s['start_time'] - collar,
+            'end_time': [t + collar for t in s['end_time']] if isinstance(s['end_time'], list) else s['end_time'] + collar,
+        }
+    )
 
 
 @seglst_map()
@@ -489,89 +496,6 @@ def remove_overlaps(
     return t.sorted('start_time').map(correct)
 
 
-def sort_and_validate(segments: SegLST, sort, pseudo_word_level_timing, name, warn=True):
-    """
-    Args:
-        segments:
-        sort: How to sort words/segments. Options:
-            - `True`: sort by segment start time and assert that the word-level
-                        timings are sorted by start time
-            - `False`: do not sort and do not check word order
-            - `'segment'`: sort segments by start time and do not check word order
-            - `'word'`: sort words by start time
-        pseudo_word_level_timing:
-        name:
-
-    >>> from paderbox.utils.pretty import pprint
-    >>> segments = SegLST([{'words': 'c d', 'start_time': 1, 'end_time': 3}, {'words': 'a b', 'start_time': 0, 'end_time': 3}])
-    >>> sort_and_validate(segments, True, 'character_based', 'test')
-    Traceback (most recent call last):
-    ...
-    ValueError: The order of word-level timings contradicts the segment-level order in test: 2 of 4 times.
-    Consider setting sort to False or "segment" or "word".
-    >>> pprint(sort_and_validate(segments, False, 'character_based', 'test'))
-    SegLST([{'words': 'c', 'start_time': 1.0, 'end_time': 2.0},
-            {'words': 'd', 'start_time': 2.0, 'end_time': 3.0},
-            {'words': 'a', 'start_time': 0.0, 'end_time': 1.5},
-            {'words': 'b', 'start_time': 1.5, 'end_time': 3.0}])
-    >>> pprint(sort_and_validate(segments, 'segment', 'character_based', 'test'))
-    SegLST([{'words': 'a', 'start_time': 0.0, 'end_time': 1.5},
-            {'words': 'b', 'start_time': 1.5, 'end_time': 3.0},
-            {'words': 'c', 'start_time': 1.0, 'end_time': 2.0},
-            {'words': 'd', 'start_time': 2.0, 'end_time': 3.0}])
-    >>> pprint(sort_and_validate(segments, 'word', 'character_based', 'test'))
-    SegLST([{'words': 'a', 'start_time': 0.0, 'end_time': 1.5},
-            {'words': 'c', 'start_time': 1.0, 'end_time': 2.0},
-            {'words': 'b', 'start_time': 1.5, 'end_time': 3.0},
-            {'words': 'd', 'start_time': 2.0, 'end_time': 3.0}])
-    """
-    if sort not in (True, False, 'segment', 'word'):
-        raise ValueError(
-            f'Invalid value for sort: {sort}. Choose one of True, False, '
-            f'"segment", "word"'
-        )
-
-    for s in segments:
-        if s['end_time'] < s['start_time']:
-            raise ValueError(
-                f'The end time of an interval must be larger than the start '
-                f'time. Found {s} in {name}'
-            )
-
-    if sort in (True, 'segment', 'word'):
-        segments = segments.sorted('start_time')
-
-    words = get_pseudo_word_level_timings(segments, pseudo_word_level_timing)
-
-    # Check whether words are sorted by start time
-    words_sorted = words.sorted('start_time')
-    if warn and words_sorted != words:
-        # This check should be fast because `sorted` doesn't change the identity
-        # of the contained objects (so `words_sorted[0] is words[0] == True`
-        # when they are sorted).
-        contradictions = [a != b for a, b in zip(words_sorted, words)]
-        try:
-            session_ids = f' (session ids: {sorted(set(segments.T["session_id"]))})'
-        except KeyError:
-            session_ids = ''
-        msg = (
-            f'The order of word-level timings contradicts the segment-level '
-            f'order in {name}: {sum(contradictions)} of {len(contradictions)} '
-            f'times.{session_ids}'
-        )
-        if sort is not True:
-            logger.warning(msg)
-        else:
-            raise ValueError(
-                f'{msg}\nConsider setting sort to False or "segment" or "word".'
-            )
-
-    if sort == 'word':
-        words = words_sorted
-
-    return words
-
-
 def get_self_overlap(d: SegLST):
     """
     Returns the self-overlap of the transcript.
@@ -632,8 +556,8 @@ def time_constrained_siso_levenshtein_distance(
     return time_constrained_levenshtein_distance(
         reference=reference.T['words'],
         hypothesis=hypothesis.T['words'],
-        reference_timing=list(zip(reference.T['start_time'], reference.T['end_time'])),
-        hypothesis_timing=list(zip(hypothesis.T['start_time'], hypothesis.T['end_time'])),
+        reference_timing=reference.T['start_time', 'end_time'],
+        hypothesis_timing=hypothesis.T['start_time', 'end_time'],
     )
 
 
@@ -687,33 +611,35 @@ def time_constrained_siso_word_error_rate(
         py_convert=None
     )
 
-    # Only single-speaker transcripts are supported, but we can here have
-    # multiple segments, e.g., for word-level transcripts
-    assert 'speaker' not in reference.T.keys() or len(reference.unique('speaker')) <= 1, 'Only single-speaker transcripts are supported'
-    assert 'speaker' not in hypothesis.T.keys() or len(hypothesis.unique('speaker')) <= 1, 'Only single-speaker transcripts are supported'
+    if 'speaker' in reference.T.keys() and len(reference.unique('speaker')) > 1:
+        raise ValueError(
+            f'Only single-speaker transcripts are supported, but found '
+            f'{len(reference)} speakers ({reference.T["speaker"]}) in '
+            f'the reference.'
+        )
+    if 'speaker' in hypothesis.T.keys() and len(hypothesis.unique('speaker')) > 1:
+        raise ValueError(
+            f'Only single-speaker transcripts are supported, but found '
+            f'{len(hypothesis)} speakers ({hypothesis.T["speaker"]}) in '
+            f'the hypothesis.'
+        )
 
-    _reference = sort_and_validate(
-        reference,
-        reference_sort,
-        reference_pseudo_word_level_timing,
-        'reference'
+    reference, hypothesis, ref_self_overlap, hyp_self_overlap = preprocess(
+        reference, hypothesis,
+        keep_keys=('start_time', 'end_time', 'words'),
+        reference_sort=reference_sort, hypothesis_sort=hypothesis_sort,
+        reference_pseudo_word_level_timing=reference_pseudo_word_level_timing,
+        hypothesis_pseudo_word_level_timing=hypothesis_pseudo_word_level_timing,
+        collar=collar,
+        segment_representation='word',
     )
-    _hypothesis = sort_and_validate(
-        hypothesis,
-        hypothesis_sort,
-        hypothesis_pseudo_word_level_timing,
-        'hypothesis'
-    )
-    _hypothesis = apply_collar(_hypothesis, collar)
 
-    er = _time_constrained_siso_error_rate(_reference, _hypothesis)
+    er = _time_constrained_siso_error_rate(reference, hypothesis)
 
-    # pseudo_word_level_timing and collar change the time stamps,
-    # hence calculate the overlap with the original time stamps
     er = replace(
         er,
-        reference_self_overlap=get_self_overlap(reference),
-        hypothesis_self_overlap=get_self_overlap(hypothesis),
+        reference_self_overlap=ref_self_overlap,
+        hypothesis_self_overlap=hyp_self_overlap,
     )
     return er
 
@@ -752,17 +678,23 @@ def time_constrained_minimum_permutation_word_error_rate(
     - 'segment': sort by segment start time and don't check word order
     - 'word': sort by word start time
     """
-    from meeteval.wer.wer.cp import _cp_error_rate
-    reference, hypothesis, reference_self_overlap, hypothesis_self_overlap = preprocess_time_constrained(
+    from meeteval.wer.wer.cp import _minimum_permutation_word_error_rate
+    reference, hypothesis, reference_self_overlap, hypothesis_self_overlap = preprocess(
         asseglst(reference, required_keys=('start_time', 'end_time', 'words', 'speaker')),
         asseglst(hypothesis, required_keys=('start_time', 'end_time', 'words', 'speaker')),
-        collar, reference_pseudo_word_level_timing, hypothesis_pseudo_word_level_timing,
-        reference_sort, hypothesis_sort,
+        keep_keys=('start_time', 'end_time', 'words', 'speaker'),
         remove_empty_segments=False,
+        reference_sort=reference_sort,
+        hypothesis_sort=hypothesis_sort,
+        collar=collar,
+        reference_pseudo_word_level_timing=reference_pseudo_word_level_timing,
+        hypothesis_pseudo_word_level_timing=hypothesis_pseudo_word_level_timing,
+        segment_representation='word',
     )
 
-    er = _cp_error_rate(
-        reference, hypothesis,
+    er = _minimum_permutation_word_error_rate(
+        reference.groupby('speaker'),
+        hypothesis.groupby('speaker'),
         distance_fn=time_constrained_siso_levenshtein_distance,
         siso_error_rate=_time_constrained_siso_error_rate,
     )
@@ -772,108 +704,6 @@ def time_constrained_minimum_permutation_word_error_rate(
         hypothesis_self_overlap=hypothesis_self_overlap,
     )
     return er
-
-
-def preprocess_time_constrained(
-        reference,
-        hypothesis,
-        collar,
-        reference_pseudo_word_level_timing,
-        hypothesis_pseudo_word_level_timing,
-        reference_sort,
-        hypothesis_sort,
-        add_segment_index='segment',    # segment | word | False
-        convert_to_int=True,
-        remove_empty_segments=True,
-):
-    # Convert before calling this function if special parameters are required
-    reference = asseglst(reference)
-    hypothesis = asseglst(hypothesis)
-
-    check_single_filename(reference, hypothesis)
-
-    # Add a segment index to the reference so that we can later find words that
-    # come from the same segment
-    if add_segment_index == 'segment':
-        if 'segment_index' not in reference.T.keys():
-            for i, s in enumerate(reference):
-                s['segment_index'] = i
-        if 'segment_index' not in hypothesis.T.keys():
-            for i, s in enumerate(hypothesis):
-                s['segment_index'] = i
-
-    # Preprocess per speaker
-    reference = reference.groupby('speaker')
-    hypothesis = hypothesis.groupby('speaker')
-
-    # Compute self-overlap for ref and hyp before converting to words and
-    # applying the collar. This is required later
-    # Add zero to work with empty reference and/or hypothesis
-    reference_self_overlap = sum(
-        [get_self_overlap(v) for v in reference.values()]
-    ) + SelfOverlap.zero()
-    hypothesis_self_overlap = sum(
-        [get_self_overlap(v) for v in hypothesis.values()]
-    ) + SelfOverlap.zero()
-    if reference_self_overlap.total_time == 0:
-        reference_self_overlap = None
-    if hypothesis_self_overlap.total_time == 0:
-        hypothesis_self_overlap = None
-
-    # Convert segments into lists of words and word-level timings
-    reference = {
-        k: sort_and_validate(
-            v,
-            reference_sort,
-            reference_pseudo_word_level_timing,
-            f'reference speaker "{k}"'
-        )
-        for k, v in reference.items()
-    }
-    hypothesis = {
-        k: sort_and_validate(
-            v,
-            hypothesis_sort,
-            hypothesis_pseudo_word_level_timing,
-            f'hypothesis speaker "{k}"'
-        )
-        for k, v in hypothesis.items()
-    }
-
-    reference = SegLST.merge(*reference.values())
-    hypothesis = SegLST.merge(*hypothesis.values())
-
-    hypothesis = apply_collar(hypothesis, collar)
-
-    # Remove empty segments as they have no effect on the WER
-    if remove_empty_segments:
-        reference = reference.filter(lambda s: s['words'])
-        hypothesis = hypothesis.filter(lambda s: s['words'])
-
-    if add_segment_index == 'word':
-        if 'segment_index' not in reference.T.keys():
-            for i, s in enumerate(reference):
-                s['segment_index'] = i
-        if 'segment_index' not in hypothesis.T.keys():
-            for i, s in enumerate(hypothesis):
-                s['segment_index'] = i
-
-    if convert_to_int:
-        reference, hypothesis = words_to_int(reference, hypothesis)
-
-    return reference, hypothesis, reference_self_overlap, hypothesis_self_overlap
-
-
-def _tcp_wer(reference, hypothesis):
-    """
-    tcpWER core code without any preprocessing
-    """
-    from meeteval.wer.wer.cp import _cp_error_rate
-    return _cp_error_rate(
-        reference, hypothesis,
-        distance_fn=time_constrained_siso_levenshtein_distance,
-        siso_error_rate=_time_constrained_siso_error_rate,
-    )
 
 
 tcp_word_error_rate = time_constrained_minimum_permutation_word_error_rate
@@ -1032,42 +862,55 @@ def align(
         required_keys=('start_time', 'end_time', 'words'),
         py_convert=None
     )
-    reference = sort_and_validate(
-        reference,
-        reference_sort,
-        reference_pseudo_word_level_timing,
-        'reference'
+
+    # Preprocess, but do not add the collar yet, because we need the original
+    # timestamps later
+    reference, hypothesis, _, _ = preprocess(
+        reference, hypothesis,
+        reference_sort=reference_sort,
+        hypothesis_sort=hypothesis_sort,
+        reference_pseudo_word_level_timing=reference_pseudo_word_level_timing,
+        hypothesis_pseudo_word_level_timing=hypothesis_pseudo_word_level_timing,
+        segment_representation='word',
+        segment_index='word' if style == 'index' else False,
+        remove_empty_segments=True,
     )
-    hypothesis = sort_and_validate(
-        hypothesis,
-        hypothesis_sort,
-        hypothesis_pseudo_word_level_timing,
-        'hypothesis'
-    )
+    # reference = sort_and_validate(
+    #     reference,
+    #     reference_sort,
+    #     reference_pseudo_word_level_timing,
+    #     'reference'
+    # )
+    # hypothesis = sort_and_validate(
+    #     hypothesis,
+    #     hypothesis_sort,
+    #     hypothesis_pseudo_word_level_timing,
+    #     'hypothesis'
+    # )
 
     # Add index for tracking across filtering operations. This is only required
     # for the index style since all other styles can be constructed from seglst
     # without the index. Especially for `style = 'seglst'` we want to keep
     # identity
-    if style == 'index':
-        reference = SegLST(
-            [{**s, '__align_index': i} for i, s in enumerate(reference)]
-        )
-        hypothesis = SegLST(
-            [{**s, '__align_index': i} for i, s in enumerate(hypothesis)]
-        )
+    # if style == 'index':
+    #     reference = SegLST(
+    #         [{**s, '__align_index': i} for i, s in enumerate(reference)]
+    #     )
+    #     hypothesis = SegLST(
+    #         [{**s, '__align_index': i} for i, s in enumerate(hypothesis)]
+    #     )
 
     # Ignore empty segments
-    reference = reference.filter(lambda s: s['words'])
-    hypothesis = hypothesis.filter(lambda s: s['words'])
+    # reference = reference.filter(lambda s: s['words'])
+    # hypothesis = hypothesis.filter(lambda s: s['words'])
 
     hypothesis_ = apply_collar(hypothesis, collar=collar)
 
     # Compute the alignment with Cython code
     reference_words = reference.T['words']
-    reference_timing = list(zip(reference.T['start_time'], reference.T['end_time']))
+    reference_timing = reference.T['start_time', 'end_time']
     hypothesis_words = hypothesis_.T['words']
-    hypothesis_timing = list(zip(hypothesis_.T['start_time'], hypothesis_.T['end_time']))
+    hypothesis_timing = hypothesis_.T['start_time', 'end_time']
 
     from meeteval.wer.matching.cy_levenshtein import time_constrained_levenshtein_distance_with_alignment
     alignment = time_constrained_levenshtein_distance_with_alignment(
@@ -1084,8 +927,8 @@ def align(
         # Use the "global" (before filtering) index so that it corresponds to
         # the input when the input already consists of words
         alignment = [
-            (None if a is None else a['__align_index'],
-             None if b is None else b['__align_index'])
+            (None if a is None else a['segment_index'],
+             None if b is None else b['segment_index'])
             for a, b in alignment
         ]
     elif style in ('kaldi', 'words'):

--- a/meeteval/wer/wer/time_constrained_orc.py
+++ b/meeteval/wer/wer/time_constrained_orc.py
@@ -67,7 +67,7 @@ def time_constrained_orc_wer(
 
     reference, hypothesis, ref_self_overlap, hyp_self_overlap = preprocess(
         reference, hypothesis,
-        keep_keys=('words', 'segment_index', 'speaker'),
+        keep_keys=('words', 'segment_index', 'speaker', 'start_time', 'end_time'),
         reference_sort=reference_sort,
         hypothesis_sort=hypothesis_sort,
         reference_pseudo_word_level_timing=reference_pseudo_word_level_timing,

--- a/meeteval/wer/wer/time_constrained_orc.py
+++ b/meeteval/wer/wer/time_constrained_orc.py
@@ -1,6 +1,7 @@
 import functools
 import typing
 
+from meeteval.wer.wer.time_constrained import _time_constrained_siso_error_rate
 
 if typing.TYPE_CHECKING:
     from meeteval.io import STM
@@ -20,7 +21,7 @@ def time_constrained_orc_wer(
         hypothesis_pseudo_word_level_timing='character_based_points',
         hypothesis_sort='segment',
         reference_sort='segment',
-) -> OrcErrorRate:
+) -> 'OrcErrorRate':
     """
     The time-constrained version of the ORC-WER (tcORC-WER).
 
@@ -61,12 +62,14 @@ def time_constrained_orc_wer(
         reference, hypothesis,
         functools.partial(
             preprocess_time_constrained,
-            reference, hypothesis, collar,
-            reference_pseudo_word_level_timing, hypothesis_pseudo_word_level_timing,
-            reference_sort, hypothesis_sort,
+            collar=collar,
+            reference_pseudo_word_level_timing=reference_pseudo_word_level_timing,
+            hypothesis_pseudo_word_level_timing=hypothesis_pseudo_word_level_timing,
+            reference_sort=reference_sort,
+            hypothesis_sort=hypothesis_sort,
             convert_to_int=False
         ),
-        matching
+        matching, _time_constrained_siso_error_rate
     )
 
 

--- a/meeteval/wer/wer/time_constrained_orc.py
+++ b/meeteval/wer/wer/time_constrained_orc.py
@@ -1,14 +1,10 @@
-import meeteval
-from meeteval.wer import combine_error_rates
-from meeteval.wer.wer.orc import OrcErrorRate, apply_orc_assignment
-from meeteval.wer.wer.time_constrained import get_self_overlap
-from meeteval.wer.wer.utils import check_single_filename
-
+import functools
 import typing
+
 
 if typing.TYPE_CHECKING:
     from meeteval.io import STM
-    from meeteval.wer.wer.cp import CPErrorRate
+    from meeteval.wer import OrcErrorRate
 
 __all__ = [
     'time_constrained_orc_wer',
@@ -24,7 +20,7 @@ def time_constrained_orc_wer(
         hypothesis_pseudo_word_level_timing='character_based_points',
         hypothesis_sort='segment',
         reference_sort='segment',
-):
+) -> OrcErrorRate:
     """
     The time-constrained version of the ORC-WER (tcORC-WER).
 
@@ -39,8 +35,10 @@ def time_constrained_orc_wer(
     OrcErrorRate(errors=1, length=0, insertions=1, deletions=0, substitutions=0, reference_self_overlap=SelfOverlap(overlap_rate=0.0, overlap_time=0, total_time=1), hypothesis_self_overlap=SelfOverlap(overlap_rate=0.0, overlap_time=0, total_time=1), assignment=('A',))
     >>> time_constrained_orc_wer([{'session_id': 'a', 'start_time': 0, 'end_time': 1, 'words': 'a b', 'speaker': 'A'}], [{'session_id': 'a', 'start_time': 0, 'end_time': 1, 'words': 'a d', 'speaker': 'A'}])
     OrcErrorRate(error_rate=0.5, errors=1, length=2, insertions=0, deletions=0, substitutions=1, reference_self_overlap=SelfOverlap(overlap_rate=0.0, overlap_time=0, total_time=1), hypothesis_self_overlap=SelfOverlap(overlap_rate=0.0, overlap_time=0, total_time=1), assignment=('A',))
-
     """
+    from meeteval.wer.wer.orc import _orc_error_rate
+    from meeteval.wer.wer.time_constrained import preprocess_time_constrained
+
     if reference_sort == 'word':
         raise ValueError(
             'reference_sort="word" is not supported for time-constrained '
@@ -48,126 +46,27 @@ def time_constrained_orc_wer(
             'continuously in the reference.'
         )
 
-    # Convert to seglst
-    original_reference = reference = meeteval.io.asseglst(reference)
-    original_hypothesis = hypothesis = meeteval.io.asseglst(hypothesis)
-    check_single_filename(reference, hypothesis)
-
-    # Add a segment index to the reference so that we can later find words that
-    # come from the same segment. Do this before removing empty segments so that
-    # we can still find the original segments in the reference after the
-    # assignment.
-    for i, s in enumerate(reference):
-        s['segment_index'] = i
-
-    # Group by stream. For ORC-WER, only hypothesis must be grouped
-    hypothesis = hypothesis.groupby('speaker')
-
-    # Calculate self-overlap before modifying the segments
-    reference_self_overlap = sum(
-        [get_self_overlap(h) for h in reference.groupby('speaker').values()]
-    ) if len(reference) > 0 else None
-    hypothesis_self_overlap = sum(
-        [get_self_overlap(h) for h in hypothesis.values()]
-    ) if len(hypothesis) > 0 else None
-
-    # Remove empty segments
-    reference_missing_segments = reference.filter(lambda s: s['words'] == '')
-    reference = reference.filter(lambda s: s['words'] != '')
-    hypothesis = {
-        k: h.filter(lambda s: s['words'] != '')
-        for k, h in hypothesis.items()
-    }
-
-    # Time-constrained preprocessing
-    from meeteval.wer.wer.time_constrained import sort_and_validate, apply_collar
-
-    # Note: We will very likely have overlaps that result in word-order changes
-    # in the reference because we treat all speakers as one stream. This is no
-    # issue for the ORC alignment algorithm! We do not want to spam the user
-    # with meaningless warnings here, thus warn=False.
-    reference = sort_and_validate(
-        reference,
-        reference_sort,
-        reference_pseudo_word_level_timing,
-        f'reference',
-        warn=False,
-    )
-    hypothesis = {
-        k: apply_collar(sort_and_validate(
-            h,
-            hypothesis_sort,
-            hypothesis_pseudo_word_level_timing,
-            f'hypothesis speaker "{k}"'
-        ), collar) for k, h in hypothesis.items()
-    }
-
-    # Compute the time-constrained ORC distance
-    from meeteval.wer.matching.cy_time_constrained_orc_matching import time_constrained_orc_levenshtein_distance
-    distance, assignment = time_constrained_orc_levenshtein_distance(
-        [segment.T['words'] for segment in reference.groupby('segment_index').values()],
-        [stream.T['words'] for stream in hypothesis.values()],
-        [list(zip(segment.T['start_time'], segment.T['end_time'])) for segment in
-         reference.groupby('segment_index').values()],
-        [list(zip(stream.T['start_time'], stream.T['end_time'])) for stream in hypothesis.values()],
-    )
-
-    # Translate the assignment from hypothesis index to stream id
-    hypothesis_keys = list(hypothesis.keys()) or ['dummy']
-    assignment = [hypothesis_keys[h] for h in assignment]
-
-    # Apply assignment
-    reference_new, _ = apply_orc_assignment(assignment, reference, hypothesis)
-
-    # Put the original segments back by inserting empty segments that were
-    # removed in the beginning. Sort by segment_index to get the assignment in
-    # the same order as the input to this function.
-    # TODO: Estimate the stream for the missing segments
-    reference_missing_segments = reference_missing_segments.map(
-        lambda s: {**s, 'speaker': hypothesis_keys[0]}
-    )
-    reference_new = meeteval.io.SegLST.merge(
-        reference_new, reference_missing_segments
-    ).sorted('segment_index')
-    assignment = tuple([
-        v[0]['speaker']
-        for v in reference_new.groupby('segment_index').values()
-    ])
-
-    # Apply the assignment to the original reference for the consistency check.
-    original_reference, _ = apply_orc_assignment(assignment, original_reference, original_hypothesis)
-
-    # Group by speaker
-    reference_new = original_reference.groupby('speaker')
-    original_hypothesis = original_hypothesis.groupby('speaker')
-
-    # Consistency check: Compute WER with the siso algorithm after applying the
-    # assignment and compare the result with the distance from the ORC algorithm
-    from meeteval.wer.wer.time_constrained import time_constrained_siso_word_error_rate
-    er = combine_error_rates(*[
-        time_constrained_siso_word_error_rate(
-            reference_new.get(k, meeteval.io.SegLST([])),
-            original_hypothesis.get(k, meeteval.io.SegLST([])),
-            reference_pseudo_word_level_timing=reference_pseudo_word_level_timing,
-            hypothesis_pseudo_word_level_timing=hypothesis_pseudo_word_level_timing,
-            collar=collar,
-            reference_sort=reference_sort,
-            hypothesis_sort=hypothesis_sort,
+    def matching(reference, hypothesis):
+        # Compute the time-constrained ORC distance
+        from meeteval.wer.matching.cy_time_constrained_orc_matching import time_constrained_orc_levenshtein_distance
+        return time_constrained_orc_levenshtein_distance(
+            [segment.T['words'] for segment in reference.groupby('segment_index').values()],
+            [stream.T['words'] for stream in hypothesis.values()],
+            [list(zip(segment.T['start_time'], segment.T['end_time'])) for segment in
+             reference.groupby('segment_index').values()],
+            [list(zip(stream.T['start_time'], stream.T['end_time'])) for stream in hypothesis.values()],
         )
-        for k in set(hypothesis.keys()) | set(reference_new.keys())
-    ])
-    length = len(reference)
-    assert er.length == length, (length, er)
-    assert er.errors == distance, (distance, er, assignment)
 
-    return OrcErrorRate(
-        er.errors, er.length,
-        insertions=er.insertions,
-        deletions=er.deletions,
-        substitutions=er.substitutions,
-        assignment=tuple(assignment),
-        reference_self_overlap=reference_self_overlap,
-        hypothesis_self_overlap=hypothesis_self_overlap,
+    return _orc_error_rate(
+        reference, hypothesis,
+        functools.partial(
+            preprocess_time_constrained,
+            reference, hypothesis, collar,
+            reference_pseudo_word_level_timing, hypothesis_pseudo_word_level_timing,
+            reference_sort, hypothesis_sort,
+            convert_to_int=False
+        ),
+        matching
     )
 
 
@@ -179,7 +78,7 @@ def time_constrained_orc_wer_multifile(
         hypothesis_sort='segment',
         reference_sort='segment',
         partial=False,
-) -> 'dict[str, CPErrorRate]':
+) -> 'dict[str, OrcErrorRate]':
     from meeteval.io.seglst import apply_multi_file
     r = apply_multi_file(lambda r, h: time_constrained_orc_wer(
         r, h,

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -113,7 +113,7 @@ def exec_with_source(code, filename, lineno, globals_=None, locals_=None):
             for codeblock in get_fenced_code_blocks(filename.read_text())
         ]
 )
-def test_readme(filename, codeblock, global_state, monkeypatch):
+def test_docs(filename, codeblock, global_state, monkeypatch):
     """Run fenced code blocks in markdown files in the MeetEval repository."""
     # Some code blocks in the readme file must run in the meeteval root directory
     # because they access the example files in `MEETEVAL_ROOT/example_files`

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -1,0 +1,142 @@
+from pathlib import Path
+import pytest
+import meeteval
+from meeteval.wer.preprocess import _preprocess_single
+
+example_files = (Path(__file__).parent.parent / 'example_files').absolute()
+
+
+@pytest.fixture
+def example_seglst():
+    return meeteval.io.load(example_files / 'hyp.seglst.json')
+
+
+@pytest.mark.parametrize('keep_keys', [None])
+@pytest.mark.parametrize('sort', ['word', 'segment', False])
+@pytest.mark.parametrize('remove_empty_segments', ['True', 'False'])
+@pytest.mark.parametrize('word_level_timing_strategy', [None, 'equidistant_points', 'character_based_points'])
+@pytest.mark.parametrize('collar', [0, 5])
+@pytest.mark.parametrize('segment_index', ['word', 'segment', False])
+@pytest.mark.parametrize('segment_representation', ['segment', 'word', 'speaker'])
+def test_preprocess_single(
+        example_seglst,
+        keep_keys,
+        sort,
+        remove_empty_segments,
+        word_level_timing_strategy,
+        collar,
+        segment_index,
+        segment_representation,
+):
+    # Skip tests with invalid configurations
+    # TODO: can we do this in a more elegant way?
+    if (
+            segment_index == 'word' and segment_representation != 'word'
+            or sort == 'word' and segment_index != 'word'
+    ):
+        pytest.skip()
+
+    _preprocess_single(
+        example_seglst,
+        keep_keys=keep_keys,
+        sort=sort,
+        remove_empty_segments=remove_empty_segments,
+        word_level_timing_strategy=word_level_timing_strategy,
+        collar=collar,
+        segment_index=segment_index,
+        segment_representation=segment_representation,
+    )
+
+
+def test_preprocess_sort_false(example_seglst):
+    processed, _ = _preprocess_single(
+        example_seglst,
+        sort=False,
+        segment_representation='segment',
+    )
+    assert processed.T['start_time'] == example_seglst.T['start_time']
+
+
+def test_preprocess_sort_segment(example_seglst):
+    processed, _ = _preprocess_single(
+        example_seglst, sort='segment',
+        segment_representation='segment',
+
+    )
+    assert processed.T['start_time'] == sorted(example_seglst.T['start_time'])
+
+
+def test_preprocess_sort_word(example_seglst):
+    processed, _ = _preprocess_single(
+        example_seglst, sort='word',
+        segment_representation='word',
+
+    )
+    assert processed.T['start_time'] == sorted(processed.T['start_time'])
+
+
+def test_preprocess_segment_representation_word(example_seglst):
+    processed, _ = _preprocess_single(
+        example_seglst, segment_representation='word',
+    )
+    assert not any(' ' in words for words in processed.T['words'])
+
+
+def test_preprocess_segment_representation_segment(example_seglst):
+    processed, _ = _preprocess_single(
+        example_seglst, segment_representation='segment',
+    )
+    assert len(example_seglst) == len(processed)
+
+
+def test_preprocess_segment_representation_speaker(example_seglst):
+    processed, _ = _preprocess_single(
+        example_seglst, segment_representation='speaker',
+    )
+    assert set(processed.T['speaker']) == set(example_seglst.T['speaker'])
+    assert len(processed) == len(set(example_seglst.T['speaker']))
+
+
+def test_preprocess_remove_empty_segments(example_seglst):
+    processed, _ = _preprocess_single(
+        example_seglst,
+        remove_empty_segments=True,
+        segment_representation='segment',
+    )
+    # No empty segments in example
+    assert len(example_seglst) == len(processed)
+
+    # Insert empty examples
+    example_seglst_empty = meeteval.io.SegLST.merge(
+        example_seglst,
+        meeteval.io.SegLST([{
+            'start_time': 0,
+            'end_time': 1,
+            'words': '',
+        }])
+    )
+    processed, _ = _preprocess_single(
+        example_seglst_empty,
+        remove_empty_segments=True,
+        segment_representation='segment',
+    )
+    # No empty segments in example
+    assert len(example_seglst) == len(processed)
+
+def test_preprocess_remove_empty_segments(example_seglst):
+    # Insert empty examples
+    example_seglst_empty = meeteval.io.SegLST.merge(
+        example_seglst,
+        meeteval.io.SegLST([{
+            'start_time': 0,
+            'end_time': 1,
+            'words': '',
+        }])
+    )
+    processed, _ = _preprocess_single(
+        example_seglst_empty,
+        remove_empty_segments=False,
+        segment_representation='segment',
+    )
+    # No empty segments in example
+    assert len(example_seglst_empty) == len(processed)

--- a/tests/test_time_constrained_orc_matching.py
+++ b/tests/test_time_constrained_orc_matching.py
@@ -53,7 +53,7 @@ def test_tcorc_vs_orc(reference, hypothesis):
     from meeteval.wer.wer.orc import orc_word_error_rate
     from meeteval.wer.wer.time_constrained_orc import time_constrained_orc_wer
 
-    orc = orc_word_error_rate(reference, hypothesis)
+    orc = orc_word_error_rate(reference, hypothesis, reference_sort=False, hypothesis_sort=False)
 
     # Without time constraint (collar is larger than the maximum length)
     # and without sorting because the low-level ORC-WER doesn't sort
@@ -139,6 +139,10 @@ def test_examples_zero_self_overlap():
 
 
 def test_assignment_keeps_order():
+    """
+    Tests that elements in the assignment corrspond to the order in the input
+    to the orc_wer function, not the sorted segments.
+    """
     from meeteval.wer.wer.time_constrained_orc import time_constrained_orc_wer
 
     tcorc = time_constrained_orc_wer(

--- a/tests/test_time_constrained_orc_matching.py
+++ b/tests/test_time_constrained_orc_matching.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import pytest
-from hypothesis import assume, settings, given, strategies as st
+from hypothesis import assume, settings, given, strategies as st, reproduce_failure
 
 from meeteval.io import SegLST
 
@@ -75,7 +75,7 @@ def test_orc_bound_by_tcorc(reference, hypothesis):
     from meeteval.wer.wer.orc import orc_word_error_rate
     from meeteval.wer.wer.time_constrained_orc import time_constrained_orc_wer
 
-    orc = orc_word_error_rate(reference, hypothesis)
+    orc = orc_word_error_rate(reference, hypothesis, reference_sort=False, hypothesis_sort=False)
     tcorc = time_constrained_orc_wer(reference, hypothesis, collar=0.1, reference_sort=False, hypothesis_sort=False)
 
     # error_rate can be None when length is None


### PR DESCRIPTION
Add functions for input preprocessing that are shared across WER functions. This removes some duplicate code (or code that was not exactly duplicated but did essentially the same thing).

This is also a preparation for adding the DI-cpWER and the greedy algorithm for the ORC-WER and DI-cpWER to prevent adding the same code there again.

Now, non-time-constrained WERs also compute self-overlap if timestamps are given.