### PR TITLE
Add greedy orc WER

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ MeetEval supports the following metrics for meeting transcription evaluation:
   `meeteval-wer cpwer -r ref.stm -h hyp.stm`
 - **Optimal Reference Combination Word Error Rate (ORC WER)**<br>
   `meeteval-wer orcwer -r ref.stm -h hyp.stm`
+- **Fast Greedy Approximation of Optimal Reference Combination Word Error Rate (greedy ORC WER)**<br>
+  `meeteval-wer greedy_orcwer -r ref.stm -h hyp.stm`
 - **Multi-speaker-input multi-stream-output Word Error Rate (MIMO WER)**<br>
   `meeteval-wer mimower -r ref.stm -h hyp.stm`
 - **Time-Constrained minimum-Permutation Word Error Rate (tcpWER)**<br>

--- a/doc/algorithms.md
+++ b/doc/algorithms.md
@@ -373,6 +373,10 @@ assert orc_lev_dynamic_programming(['a', 'bc'], ['bc', 'a']) == 0
 
 ### Greedy Algorithm for the ORC Levenshtein distance
 
+> [!NOTE]
+> 
+> [View Python / Cython / Numpy Implementation](../meeteval/wer/matching/greedy_combination_matching.py)
+
 Even the dynamic programming algorithm can be infeasible when the number of output streams increases.
 The ORC Levenshtein distance can be approximated with high accuracy by a greedy algorithm.
 The greedy algorithm gradually improves an assignment by checking for every utterance whether switching its label would decrease the distance.

--- a/meeteval/wer/__main__.py
+++ b/meeteval/wer/__main__.py
@@ -189,7 +189,6 @@ def greedy_orcwer(
         regex=None,
         reference_sort='segment_if_available',
         hypothesis_sort='segment_if_available',
-        assignment_initialization='cp',
         uem=None,
         partial=False,
         normalizer=None,
@@ -203,7 +202,6 @@ def greedy_orcwer(
         uem=uem,
         partial=partial,
         normalizer=normalizer,
-        assignment_initialization=assignment_initialization,
     )
     _save_results(results, hypothesis, per_reco_out, average_out)
 
@@ -550,17 +548,6 @@ class CLI:
                      '- None: Do nothing (default)\n'
                      '- lower,rm(.?!,): Lowercase the transcript and remove punctuations (.,?!).',
                 choices=[None, 'lower,rm(.?!,)'],
-            )
-        elif name == 'assignment_initialization':
-            command_parser.add_argument(
-                '--assignment-initialization',
-                choices=['cp', 'random', 'constant'],
-                help='Specifies how the greedy search should be initialized.\n'
-                     'Choices:\n'
-                     '- cp: Use the assignment from the cpWER. Ensures fast convergence when the speaker labels '
-                     'are already somewhat correct. Requires speaker/stream labels in both, reference and hypothesis.\n'
-                     '- random: Initializes the assignment randomly. This is not deterministic.\n'
-                     '- constant: Initializes the label for all segments to 0.'
             )
         elif name == 'partial':
             command_parser.add_argument(

--- a/meeteval/wer/__main__.py
+++ b/meeteval/wer/__main__.py
@@ -189,7 +189,6 @@ def greedy_orcwer(
         regex=None,
         reference_sort='segment_if_available',
         hypothesis_sort='segment_if_available',
-        distancetype='21',
         assignment_initialization='cp',
         uem=None,
         partial=False,
@@ -204,7 +203,6 @@ def greedy_orcwer(
         uem=uem,
         partial=partial,
         normalizer=normalizer,
-        distancetype=distancetype,
         assignment_initialization=assignment_initialization,
     )
     _save_results(results, hypothesis, per_reco_out, average_out)
@@ -552,17 +550,6 @@ class CLI:
                      '- None: Do nothing (default)\n'
                      '- lower,rm(.?!,): Lowercase the transcript and remove punctuations (.,?!).',
                 choices=[None, 'lower,rm(.?!,)'],
-            )
-        elif name == 'distancetype':
-            command_parser.add_argument(
-                '--distancetype',
-                choices=['1', '2', '21'],
-                help='Specifies the costs used for substitutions in the greedy distance calculation.\n'
-                     'Choices:\n'
-                     '- 1: A substitution cost of 1 (standard Levenshtein distance)\n'
-                     '- 2: A substitution cost of 2 (subst = ins + del)\n'
-                     '- 21: Optimize with 2 until convergence, then optimize with 1 until convergence. This is the '
-                     'default and recommended for best results.'
             )
         elif name == 'assignment_initialization':
             command_parser.add_argument(

--- a/meeteval/wer/api.py
+++ b/meeteval/wer/api.py
@@ -126,7 +126,6 @@ def greedy_orcwer(
         regex=None,
         reference_sort='segment_if_available',
         hypothesis_sort='segment_if_available',
-        distancetype='21',
         assignment_initialization='cp',
         uem=None,
         partial=False,
@@ -142,7 +141,6 @@ def greedy_orcwer(
         reference, hypothesis, partial=partial,
         reference_sort=reference_sort,
         hypothesis_sort=hypothesis_sort,
-        distancetype=distancetype,
         assignment_initialization=assignment_initialization,
     )
     return results

--- a/meeteval/wer/api.py
+++ b/meeteval/wer/api.py
@@ -9,6 +9,7 @@ from meeteval.wer.wer import ErrorRate
 __all__ = [
     'cpwer',
     'orcwer',
+    'greedy_orcwer',
     'mimower',
     'tcpwer',
     'tcorcwer',

--- a/meeteval/wer/api.py
+++ b/meeteval/wer/api.py
@@ -121,6 +121,33 @@ def orcwer(
     return results
 
 
+def greedy_orcwer(
+        reference, hypothesis,
+        regex=None,
+        reference_sort='segment_if_available',
+        hypothesis_sort='segment_if_available',
+        distancetype='21',
+        assignment_initialization='cp',
+        uem=None,
+        partial=False,
+        normalizer=None,
+):
+    """Computes the Optimal Reference Combination Word Error Rate (ORC WER)"""
+    from meeteval.wer.wer.orc import greedy_orc_word_error_rate_multifile
+    reference, hypothesis = _load_texts(
+        reference, hypothesis, regex=regex,
+        uem=uem, normalizer=normalizer,
+    )
+    results = greedy_orc_word_error_rate_multifile(
+        reference, hypothesis, partial=partial,
+        reference_sort=reference_sort,
+        hypothesis_sort=hypothesis_sort,
+        distancetype=distancetype,
+        assignment_initialization=assignment_initialization,
+    )
+    return results
+
+
 def cpwer(
         reference, hypothesis,
         regex=None,

--- a/meeteval/wer/api.py
+++ b/meeteval/wer/api.py
@@ -127,7 +127,6 @@ def greedy_orcwer(
         regex=None,
         reference_sort='segment_if_available',
         hypothesis_sort='segment_if_available',
-        assignment_initialization='cp',
         uem=None,
         partial=False,
         normalizer=None,
@@ -142,7 +141,6 @@ def greedy_orcwer(
         reference, hypothesis, partial=partial,
         reference_sort=reference_sort,
         hypothesis_sort=hypothesis_sort,
-        assignment_initialization=assignment_initialization,
     )
     return results
 

--- a/meeteval/wer/matching/cy_greedy_combination_matching.pyx
+++ b/meeteval/wer/matching/cy_greedy_combination_matching.pyx
@@ -1,0 +1,43 @@
+# distutils: language = c++
+#cython: language_level=3
+import numpy as np
+cimport cython
+cimport numpy as np
+from numpy cimport npy_uint64, npy_float64
+np.import_array()
+ctypedef unsigned int uint
+
+
+@cython.boundscheck(False)  # turn off bounds-checking for entire function
+@cython.wraparound(False)  # turn off negative index wrapping for entire function
+def cy_forward_col(
+    npy_uint64[:] column not None,
+    npy_uint64[:] a not None,
+    npy_uint64[:] b not None,
+    uint cost_substitution = 1,
+) -> np.ndarray:
+    """
+    Args:
+        column: The column to be updated
+        a: Sequence in column direction (make sure that `len(column) == len(a) + 1`! otherwise SEGFAULT!!)
+        b: Sequence in row direction. This function updates `column` `len(b)` times
+        tmp: Pre-allocated temporary memory. Must have the same shape as `column`
+        cost_substitution: Cost for a substitution
+    """
+    cdef uint i, j, a_, b_, current, prev
+    cdef npy_uint64[:, :] tmp = np.empty((2, column.shape[0]), dtype=np.uint)
+    tmp[0, ...] = column
+    current = 0
+    for j in range(b.shape[0]):
+        current = (j + 1) % 2
+        prev = j % 2
+        b_ = b[j]
+        # TODO: can we swap without copy?
+        tmp[current, 0] = tmp[prev, 0] + 1
+        for i in range(1, a.shape[0] + 1):
+            a_ = a[i - 1]
+            if a_ == b_:
+                tmp[current, i] = tmp[prev, i - 1]
+            else:
+                tmp[current, i] = min([tmp[prev, i - 1] + cost_substitution, tmp[current, i - 1] + 1, tmp[prev, i] + 1])
+    return np.asarray(tmp[current]).copy()

--- a/meeteval/wer/matching/greedy_combination_matching.py
+++ b/meeteval/wer/matching/greedy_combination_matching.py
@@ -151,7 +151,7 @@ def _greedy_correct_assignment(
         # We know that the cost cannot increase, so check that we do correct
         assert sum(old_stream_costs) >= sum(stream_costs), (old_stream_costs, stream_costs)
 
-    return assignment, np.sum(stream_costs)
+    return assignment, int(np.sum(stream_costs))
 
 
 def initialize_assignment(
@@ -239,4 +239,4 @@ def greedy_combination_matching(
             functools.partial(cy_forward_col, cost_substitution=int(d))
         )
 
-    return int(distance), assignment
+    return distance, assignment

--- a/meeteval/wer/matching/greedy_combination_matching.py
+++ b/meeteval/wer/matching/greedy_combination_matching.py
@@ -208,6 +208,7 @@ def initialize_assignment(
             else int(np.argmin(cost_matrix[int_segment_labels[segment_label], :len(streams)]))
             for i, (segment_label, stream_label) in enumerate(assignment)
         }
+        # Translate assignment to segments
         assignment = [
             assignment[k[0]['speaker']]
             for k in segments.groupby('segment_index').values()
@@ -229,7 +230,17 @@ def greedy_combination_matching(
         distancetype: str = '21',   # '21', '2', '1'
 ):
     """
-    Segments in `a` are assigned to streams in `b`.
+    Segments in `segments` are assigned to streams in `streams`.
+
+    Args:
+        segments: A list of segments for which stream labels should be obtained
+        streams: A list of streams to which the segments are assigned
+        initial_assignment: The initial assignment of the segments to the streams.
+            Can be obtained with `initialize_assignment`.
+        distancetype: The type of distance to use. Can be one of:
+            - `'1'`: Use insertion cost of 1 (like in Levenshtein distance)
+            - `'2'`: Use insertion cost of 2 (cost of insertion + deletion)
+            - `'21'`: Start with '2' until converged and then use '1' until converged
     """
     if len(segments) == 0:
         return sum([len(s) for s in streams]), []

--- a/meeteval/wer/matching/greedy_combination_matching.py
+++ b/meeteval/wer/matching/greedy_combination_matching.py
@@ -126,6 +126,12 @@ def _greedy_correct_assignment(
 
             # Find best stream_index for `stream` and update running variables
             best = int(np.argmin(cost_differences))
+
+            # If best != current_assignment but the cost doesn't change, then keep the assignment.
+            # This makes sure that an optimal assignment is not changed
+            if cost_differences[best] == cost_differences[current_assignment]:
+                best = current_assignment
+
             forward_columns[best] = updated_forward_columns[best]
             backward_indices[current_assignment] += 1
             new_assignment.append(best)

--- a/meeteval/wer/matching/greedy_combination_matching.py
+++ b/meeteval/wer/matching/greedy_combination_matching.py
@@ -1,0 +1,216 @@
+import itertools
+import functools
+from typing import List, Iterable
+
+
+import numpy as np
+
+from meeteval.io.seglst import SegLST
+from meeteval.wer.matching.cy_greedy_combination_matching import cy_forward_col
+
+
+def _apply_assignment(assignment, segments, n=None):
+    if n is None:
+        n = max(assignment) + 1
+    else:
+        n = max(max(assignment) + 1, n)
+        assert n > max(assignment), (n, max(assignment))
+    h_ = [[] for _ in range(n)]
+    for a, h in zip(assignment, segments):
+        h_[a].append(h)
+    return h_
+
+
+def _greedy_correct_assignment(
+        segments: List[np.ndarray],
+        streams: List[np.ndarray],
+        assignment: List[int],
+        forward_column: callable = cy_forward_col,
+):
+    """
+    Greedily modify the assignment (of the segments to the streams)
+    to decrease the Levenshtein distance.
+
+    Args:
+        segments: A list of segments for which stream labels should be obtained
+        streams: A list of streams to which the segments are assigned
+        assignment: The initial assignment.
+        forward_column: A function to compute a column update. Can be used
+            to switch between different cost functions, e.g. with different
+            substitution costs or with or without time constraint.
+    """
+    # Temporary variables
+    cost_differences = np.zeros((len(streams),), dtype=int)
+    costs_with_utterance = np.zeros((len(streams),), dtype=int)
+    costs_without_utterance = np.zeros((len(streams),), dtype=int)
+    updated_forward_columns = [None] * len(streams)
+
+    # Iteratively update assignment greedy
+    for num_updates in range(1, 50):
+        assert all(a < len(streams) for a in assignment), (assignment, len(streams), num_updates)
+
+        # Compute backward matrices for every stream_index
+        def compute_backward_columns(r, h):
+            backward_column = np.arange(len(h) + 1, dtype=np.uint)
+            backward_columns = [backward_column[::-1]]
+
+            for r_ in r[::-1]:
+                backward_column = forward_column(backward_column, h[::-1], r_[::-1])
+                backward_columns.insert(0, backward_column[::-1])
+            return backward_columns
+
+        backward_columns = [
+            compute_backward_columns(r, h)
+            for r, h in zip(_apply_assignment(assignment, segments, n=len(streams)), streams)
+        ]
+
+        # Keep track of the cost on the current stream_index so that we don't have to compute the min in every
+        # iteration
+        stream_costs = [bm[0][0] for bm in backward_columns]
+        old_stream_costs = stream_costs.copy()
+        backward_indices = [0] * len(streams)
+
+        # forward_columns holds the active columns of the forward matrix
+        forward_columns = [np.arange(len(h) + 1, dtype=np.uint) for h in streams]
+
+        new_assignment = []
+        for utterance_index, (current_assignment, current_segment) in enumerate(zip(assignment, segments)):
+            for stream_index, (
+                    current_forward_column, stream, current_backward_columns, current_backward_index
+            ) in enumerate(zip(forward_columns, streams, backward_columns, backward_indices)):
+                # Forward column for adding stream to stream_index `stream_index`. We always have to compute this update,
+                # even if we assign stream to stream_index `stream_index` because we might need this column in a later
+                # iteration
+                updated_column = forward_column(
+                    current_forward_column, stream, current_segment,
+                )
+
+                if stream_index == current_assignment:
+                    # Keep current assignment
+                    # Cost with is the current cost since the utterance is not moved
+                    costs_with_utterance[stream_index] = stream_costs[stream_index]
+
+                    # The cost of `stream_index` without the current utterance can be computed from the current forward column
+                    # and the backward column after the current utterance
+                    backward_column = current_backward_columns[current_backward_index + 1]
+                    costs_without_utterance[stream_index] = int(np.min(current_forward_column + backward_column))
+
+                    # The assertion is relatively expensive because it is called in the hot loop, thus disabled
+                    # assert np.min(current_forward_column + backward_column) == np.min(column + current_backward_columns[:, bm_index])
+                else:
+                    # Switch assignment: remove from `a` and add to `stream_index`
+                    # The cost of `stream_index` without `stream` is the current stream_index cost because it is moved to this stream_index
+                    costs_without_utterance[stream_index] = stream_costs[stream_index]
+
+                    # The cost of `stream_index` with `stream` is computed from the current backward column and the updated
+                    # forward column
+                    backward_column = current_backward_columns[current_backward_index]
+                    costs_with_utterance[stream_index] = int(np.min(updated_column + backward_column))
+
+                # The final assignment is found by minimizing the cost difference that results from moving the
+                # utterance to another stream_index. We track the different costs here to save computation for the
+                # later update
+                cost_differences[stream_index] = costs_with_utterance[stream_index] - costs_without_utterance[
+                    stream_index]
+                updated_forward_columns[stream_index] = updated_column
+
+            # Find best stream_index for `stream` and update running variables
+            best = int(np.argmin(cost_differences))
+            forward_columns[best] = updated_forward_columns[best]
+            backward_indices[current_assignment] += 1
+            new_assignment.append(best)
+
+            # Update the cached stream_index costs. This is only required when we change the assignment
+            # for the current segment
+            if best != current_assignment:
+                stream_costs[best] = costs_with_utterance[best]
+                stream_costs[current_assignment] = costs_without_utterance[current_assignment]
+
+        # Break when the assignment didn't change
+        if any(a != na for a, na in zip(assignment, new_assignment)):
+            assignment = new_assignment
+        else:
+            break
+
+        # We know that the cost cannot increase, so check that we do correct
+        assert sum(old_stream_costs) >= sum(stream_costs), (old_stream_costs, stream_costs)
+
+    return assignment, np.sum(stream_costs)
+
+
+def initialize_assignment(
+        segments: SegLST,
+        streams: SegLST,
+        initialization: str = 'cp',
+):
+    """
+    Args:
+        segments: A SegLST object containing the segments that are assigned to
+            the streams
+        streams: A SegLST object containing the streams.
+        initialization: How the initial stream labels are obtained before the
+            greedy algorithm starts. Can be one of:
+            - `'random'`: Assigns random initial stream labels to each segment
+            - `'constant'`: Assigns a constant stream label of 0 to each segment
+            - `'cp'`: Uses the cpWER solver to obtain the initial stream labels. Assumes
+                that the `'speaker'` key is present in both `a` and `b`.
+    """
+    if initialization == 'cp':
+        # Compute cpWER to get a good starting point
+        from meeteval.wer.wer.cp import _minimum_permutation_assignment
+        from meeteval.wer.wer.siso import siso_levenshtein_distance
+        assignment, _ = _minimum_permutation_assignment(
+            segments.groupby('speaker'),
+            streams,
+            distance_fn=siso_levenshtein_distance,
+        )
+        # Use integers for th assignment labels.
+        # Map all unmatched segments to stream 0
+        c = iter(itertools.count())
+        assignment = {
+            segment_label: next(c) if stream_label is not None else 0
+            for i, (segment_label, stream_label) in enumerate(assignment)
+        }
+        assignment = [
+            assignment[k[0]['speaker']]
+            for k in segments.groupby('segment_index').values()
+        ]
+    elif initialization == 'random':
+        assignment = np.random.choice(len(streams), len(segments))
+    elif initialization == 'constant':
+        assignment = [0] * len(segments)
+    else:
+        raise ValueError(f'Unknown initialization: {initialization}')
+    return assignment
+
+
+def greedy_combination_matching(
+        segments: List[Iterable[int]],
+        streams: List[Iterable[int]],
+        initial_assignment: List[int],
+        *,
+        distancetype: str = '21',   # '21', '2', '1'
+):
+    """
+    Segments in `a` are assigned to streams in `b`.
+    """
+    if len(segments) == 0:
+        return sum([len(s) for s in streams]), []
+    if len(streams) == 0:
+        return sum([len(s) for s in segments]), [0] * len(segments)
+
+    segments = [np.asarray(s, dtype=np.uint) for s in segments]
+    streams = [np.asarray(s, dtype=np.uint) for s in streams]
+
+    assert len(initial_assignment) == len(segments), (len(initial_assignment), len(segments), initial_assignment)
+
+    # Correct assignment
+    assignment = initial_assignment
+    assert distancetype in ('1', '2', '21'), distancetype
+    for d in distancetype:
+        assignment, distance = _greedy_correct_assignment(
+            segments, streams, assignment,
+            functools.partial(cy_forward_col, cost_substitution=int(d))
+        )
+
+    return int(distance), assignment

--- a/meeteval/wer/preprocess.py
+++ b/meeteval/wer/preprocess.py
@@ -211,7 +211,7 @@ def words_to_int(*d: 'SegLST'):
     import collections
     sym2int = collections.defaultdict(itertools.count().__next__)
 
-    d = [d_.map(lambda s: {**s, 'words': sym2int[s['words']]}) for d_ in d]
+    d = [d_.map(lambda s: {**s, 'words': [sym2int[w] for w in s['words']] if isinstance(s['words'], list) else sym2int[s['words']]}) for d_ in d]
     return d
 
 

--- a/meeteval/wer/wer/__init__.py
+++ b/meeteval/wer/wer/__init__.py
@@ -1,6 +1,6 @@
 from .cp import cp_word_error_rate, CPErrorRate, cp_word_error_rate_multifile
 from .mimo import mimo_word_error_rate, MimoErrorRate, mimo_word_error_rate_multifile
-from .orc import orc_word_error_rate, orc_word_error_rate_multifile, OrcErrorRate
+from .orc import orc_word_error_rate, orc_word_error_rate_multifile, OrcErrorRate, greedy_orc_word_error_rate, greedy_orc_word_error_rate_multifile
 from .siso import siso_word_error_rate, siso_character_error_rate, siso_word_error_rate_multifile
 from .error_rate import ErrorRate, combine_error_rates
 from .time_constrained import time_constrained_minimum_permutation_word_error_rate, time_constrained_siso_word_error_rate, tcp_word_error_rate_multifile

--- a/meeteval/wer/wer/cp.py
+++ b/meeteval/wer/wer/cp.py
@@ -227,13 +227,14 @@ def _minimum_permutation_assignment(
 
     Returns:
         The assignment and the distance
+        The score matrix. Shape (reference hypothesis)
 
     >>> _minimum_permutation_assignment({}, {}, lambda x, y: 0)
     ((), 0)
     >>> _minimum_permutation_assignment({}, {'spkA': meeteval.io.SegLST([])}, lambda x, y: 1)
-    (((None, 'spkA'),), 1)
+    (((None, 'spkA'),), 1, array([[1]]))
     >>> _minimum_permutation_assignment({'spkA': meeteval.io.SegLST([])}, {}, lambda x, y: 1)
-    ((('spkA', None),), 1)
+    ((('spkA', None),), 1, array([[1]]))
     """
     import scipy.optimize
     import numpy as np
@@ -273,7 +274,7 @@ def _minimum_permutation_assignment(
         (reference_keys.get(r), hypothesis_keys.get(c))
         for r, c in itertools.zip_longest(row_ind, col_ind)
     ])
-    return assignment, int(distance)
+    return assignment, int(distance), cost_matrix
 
 
 def _minimum_permutation_word_error_rate(
@@ -307,7 +308,7 @@ def _minimum_permutation_word_error_rate(
             f'for details.'
         )
 
-    assignment, distance = _minimum_permutation_assignment(
+    assignment, distance, _ = _minimum_permutation_assignment(
         reference, hypothesis, distance_fn, missing
     )
 

--- a/meeteval/wer/wer/orc.py
+++ b/meeteval/wer/wer/orc.py
@@ -357,10 +357,6 @@ def greedy_orc_word_error_rate(
             [[w for words in stream.T['words'] for w in words] for stream in hypothesis.values()],
             initial_assignment=initialize_assignment(reference, hypothesis, initialization=assignment_initialization),
         )
-        if not str(distance).endswith('1'):
-            # Let the wrapper compute the distance. The distance returned by the matching
-            # uses a different weight and thus has a different value
-            distance = None
         return distance, assignment
 
     def siso(reference, hypothesis):

--- a/meeteval/wer/wer/orc.py
+++ b/meeteval/wer/wer/orc.py
@@ -316,8 +316,6 @@ def greedy_orc_word_error_rate(
         hypothesis: 'SegLST',
         reference_sort='segment_if_available',
         hypothesis_sort='segment_if_available',
-        *,
-        assignment_initialization='cp',
 ):
     """
     # All correct on a single channel
@@ -355,7 +353,7 @@ def greedy_orc_word_error_rate(
         distance, assignment = greedy_combination_matching(
             reference.T['words'],
             [[w for words in stream.T['words'] for w in words] for stream in hypothesis.values()],
-            initial_assignment=initialize_assignment(reference, hypothesis, initialization=assignment_initialization),
+            initial_assignment=initialize_assignment(reference, hypothesis, initialization='cp'),
         )
         return distance, assignment
 
@@ -394,7 +392,6 @@ def greedy_orc_word_error_rate_multifile(
         partial=False,
         reference_sort='segment_if_available',
         hypothesis_sort='segment_if_available',
-        assignment_initialization='cp',
 ) -> 'dict[str, OrcErrorRate]':
     """
     Computes the ORC WER for each example in the reference and hypothesis files.
@@ -408,7 +405,6 @@ def greedy_orc_word_error_rate_multifile(
             greedy_orc_word_error_rate,
             reference_sort=reference_sort,
             hypothesis_sort=hypothesis_sort,
-            assignment_initialization=assignment_initialization,
         ), reference, hypothesis,
         partial=partial
     )

--- a/meeteval/wer/wer/orc.py
+++ b/meeteval/wer/wer/orc.py
@@ -317,7 +317,6 @@ def greedy_orc_word_error_rate(
         reference_sort='segment_if_available',
         hypothesis_sort='segment_if_available',
         *,
-        distancetype='21',
         assignment_initialization='cp',
 ):
     """
@@ -357,7 +356,6 @@ def greedy_orc_word_error_rate(
             reference.T['words'],
             [[w for words in stream.T['words'] for w in words] for stream in hypothesis.values()],
             initial_assignment=initialize_assignment(reference, hypothesis, initialization=assignment_initialization),
-            distancetype=distancetype,
         )
         if not str(distance).endswith('1'):
             # Let the wrapper compute the distance. The distance returned by the matching
@@ -400,7 +398,6 @@ def greedy_orc_word_error_rate_multifile(
         partial=False,
         reference_sort='segment_if_available',
         hypothesis_sort='segment_if_available',
-        distancetype='21',
         assignment_initialization='cp',
 ) -> 'dict[str, OrcErrorRate]':
     """
@@ -415,7 +412,6 @@ def greedy_orc_word_error_rate_multifile(
             greedy_orc_word_error_rate,
             reference_sort=reference_sort,
             hypothesis_sort=hypothesis_sort,
-            distancetype=distancetype,
             assignment_initialization=assignment_initialization,
         ), reference, hypothesis,
         partial=partial

--- a/meeteval/wer/wer/orc.py
+++ b/meeteval/wer/wer/orc.py
@@ -14,7 +14,9 @@ __all__ = [
     'OrcErrorRate',
     'orc_word_error_rate',
     'orc_word_error_rate_multifile',
-    'apply_orc_assignment'
+    'apply_orc_assignment',
+    'greedy_orc_word_error_rate',
+    'greedy_orc_word_error_rate_multifile',
 ]
 
 from meeteval.wer.preprocess import preprocess
@@ -123,7 +125,7 @@ def _orc_error_rate(
         )
         for k in set(hypothesis.keys()) | set(reference_new.keys())
     ])
-    length = len(reference)
+    length = sum([len(s['words']) if isinstance(s['words'], list) else 1 for s in reference])
     assert er.length == length, (length, er)
     assert er.errors == distance, (distance, er, assignment)
 
@@ -189,11 +191,17 @@ def orc_word_error_rate(
     def matching(reference, hypothesis):
         """Use the mimo matching algorithm. Convert inputs and outputs between the formats"""
         distance, assignment = mimo_matching(
-            [[segment.T['words'] for segment in reference.groupby('segment_index').values()]],
-            [stream.T['words'] for stream in hypothesis.values()],
+            [reference.T['words']],
+            [[w for words in stream.T['words'] for w in words] for stream in hypothesis.values()],
         )
         assignment = [a for _, a in assignment]
         return distance, assignment
+
+    def siso(reference, hypothesis):
+        return _siso_error_rate(
+            [w for words in reference.T['words'] for w in words],
+            [w for words in hypothesis.T['words'] for w in words],
+        )
 
     # Drop segment index in reference. It will get a new one after merging by speakers
     reference = meeteval.io.asseglst(reference)
@@ -204,11 +212,11 @@ def orc_word_error_rate(
         keep_keys=('words', 'segment_index', 'speaker'),
         reference_sort=reference_sort,
         hypothesis_sort=hypothesis_sort,
-        segment_representation='word',
+        segment_representation='segment',
         segment_index='segment',
         remove_empty_segments=False,
     )
-    er = _orc_error_rate(reference, hypothesis, matching, _seglst_siso_error_rate)
+    er = _orc_error_rate(reference, hypothesis, matching, siso)
     er = dataclasses.replace(
         er,
         reference_self_overlap=ref_self_overlap,
@@ -299,3 +307,109 @@ def apply_orc_assignment(
         return type(hypothesis)(reference_new.values()), hypothesis
     else:
         raise TypeError(type(hypothesis), hypothesis)
+
+
+def greedy_orc_word_error_rate(
+        reference: 'List[str | Iterable[str]] | STM',
+        hypothesis: 'List[List[Tuple[str | Iterable[str], int]]] | STM',
+        reference_sort='segment_if_available',
+        hypothesis_sort='segment_if_available',
+        *,
+        distancetype='21',
+        assignment_initialization='cp',
+):
+    """
+    # All correct on a single channel
+    >>> greedy_orc_word_error_rate(['a b', 'c d', 'e f'], ['a b c d e f'])
+    OrcErrorRate(error_rate=0.0, errors=0, length=6, insertions=0, deletions=0, substitutions=0, assignment=(0, 0, 0))
+
+    # All correct on two channels
+    >>> greedy_orc_word_error_rate(['a b', 'c d', 'e f'], ['a b', 'c d e f'])
+    OrcErrorRate(error_rate=0.0, errors=0, length=6, insertions=0, deletions=0, substitutions=0, assignment=(0, 1, 1))
+
+    # One utterance is split
+    >>> er = greedy_orc_word_error_rate(['a', 'c d', 'e'], ['a c', 'd e'])
+    >>> er
+    OrcErrorRate(error_rate=0.5, errors=2, length=4, insertions=1, deletions=1, substitutions=0, assignment=(0, 0, 1))
+    >>> er.apply_assignment(['a', 'c d', 'e'], ['a c', 'd e'])
+    ([['a', 'c d'], ['e']], ['a c', 'd e'])
+
+    >>> greedy_orc_word_error_rate(STM.parse('X 1 A 0.0 1.0 a b\\nX 1 B 0.0 2.0 e f\\nX 1 A 1.0 2.0 c d\\n'), STM.parse('X 1 1 0.0 2.0 c d\\nX 1 0 0.0 2.0 a b e f\\n'))
+    OrcErrorRate(error_rate=0.0, errors=0, length=6, insertions=0, deletions=0, substitutions=0, reference_self_overlap=SelfOverlap(overlap_rate=Decimal('0E+1'), overlap_time=0, total_time=Decimal('4.0')), hypothesis_self_overlap=SelfOverlap(overlap_rate=Decimal('0E+1'), overlap_time=0, total_time=Decimal('4.0')), assignment=('0', '0', '1'))
+
+    >>> er = greedy_orc_word_error_rate(['a', 'c d', 'e'], {'A': 'a c', 'B': 'd e'})
+    >>> er
+    OrcErrorRate(error_rate=0.5, errors=2, length=4, insertions=1, deletions=1, substitutions=0, assignment=('A', 'A', 'B'))
+    >>> er.apply_assignment(['a', 'c d', 'e'], {'A': 'a c', 'B': 'd e'})
+    ({'A': ['a', 'c d'], 'B': ['e']}, {'A': 'a c', 'B': 'd e'})
+
+    >>> greedy_orc_word_error_rate([{'session_id': 'a', 'start_time': 0, 'end_time': 1, 'words': '', 'speaker': 'A'}], [{'session_id': 'a', 'start_time': 0, 'end_time': 1, 'words': 'a', 'speaker': 'A'}])
+    OrcErrorRate(errors=1, length=0, insertions=1, deletions=0, substitutions=0, reference_self_overlap=SelfOverlap(overlap_rate=0.0, overlap_time=0, total_time=1), hypothesis_self_overlap=SelfOverlap(overlap_rate=0.0, overlap_time=0, total_time=1), assignment=('A',))
+
+    """
+    from meeteval.wer.matching.greedy_combination_matching import greedy_combination_matching, initialize_assignment
+
+    def matching(reference, hypothesis):
+        """Use the mimo matching algorithm. Convert inputs and outputs between the formats"""
+        distance, assignment = greedy_combination_matching(
+            reference.T['words'],
+            [[w for words in stream.T['words'] for w in words] for stream in hypothesis.values()],
+            initial_assignment=initialize_assignment(reference, hypothesis, initialization=assignment_initialization)
+        )
+        return distance, assignment
+
+    def siso(reference, hypothesis):
+        return _siso_error_rate(
+            [w for words in reference.T['words'] for w in words],
+            [w for words in hypothesis.T['words'] for w in words],
+        )
+
+    # Drop segment index in reference. It will get a new one after merging by speakers
+    reference = meeteval.io.asseglst(reference)
+    reference = reference.map(lambda x: {k: v for k, v in x.items() if k != 'segment_index'})
+
+    reference, hypothesis, ref_self_overlap, hyp_self_overlap = preprocess(
+        reference, hypothesis,
+        keep_keys=('words', 'segment_index', 'speaker'),
+        reference_sort=reference_sort,
+        hypothesis_sort=hypothesis_sort,
+        segment_representation='segment',
+        segment_index='segment',
+        remove_empty_segments=False,
+        convert_to_int=True,
+    )
+    er = _orc_error_rate(reference, hypothesis, matching, siso)
+    er = dataclasses.replace(
+        er,
+        reference_self_overlap=ref_self_overlap,
+        hypothesis_self_overlap=hyp_self_overlap,
+    )
+    return er
+
+
+def greedy_orc_word_error_rate_multifile(
+        reference,
+        hypothesis,
+        partial=False,
+        reference_sort='segment_if_available',
+        hypothesis_sort='segment_if_available',
+        distancetype='21',
+        assignment_initialization='cp',
+) -> 'dict[str, OrcErrorRate]':
+    """
+    Computes the ORC WER for each example in the reference and hypothesis files.
+
+    To compute the overall WER, use
+    `sum(orc_word_error_rate_multifile(r, h).values())`.
+    """
+    from meeteval.io.seglst import apply_multi_file
+    return apply_multi_file(
+        functools.partial(
+            greedy_orc_word_error_rate,
+            reference_sort=reference_sort,
+            hypothesis_sort=hypothesis_sort,
+            distancetype=distancetype,
+            assignment_initialization=assignment_initialization,
+        ), reference, hypothesis,
+        partial=partial
+    )

--- a/meeteval/wer/wer/siso.py
+++ b/meeteval/wer/wer/siso.py
@@ -35,8 +35,14 @@ def siso_levenshtein_distance(reference: 'SegLST', hypothesis: 'SegLST') -> int:
 
     from meeteval.wer.matching.cy_levenshtein import levenshtein_distance
 
-    reference = [w for w in reference.T['words'] if w]
-    hypothesis = [w for w in hypothesis.T['words'] if w]
+    reference = reference.T['words']
+    if reference and isinstance(reference[0], list):
+        reference = [w for r in reference for w in r]
+    reference = [w for w in reference if w]
+    hypothesis = hypothesis.T['words']
+    if hypothesis and isinstance(hypothesis[0], list):
+        hypothesis = [w for h in hypothesis for w in h]
+    hypothesis = [w for w in hypothesis if w]
 
     return levenshtein_distance(reference, hypothesis)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "Cython"]
+requires = ["setuptools", "wheel", "Cython", "numpy"]

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from distutils.extension import Extension
-from pathlib import Path
+import numpy
 
 from setuptools import setup, find_packages
 
@@ -27,6 +27,12 @@ ext_modules = cythonize(
         Extension(
             'meeteval.wer.matching.cy_time_constrained_orc_matching',
             ['meeteval/wer/matching/cy_time_constrained_orc_matching.pyx'],
+            extra_compile_args=['-std=c++11', '-O3'],
+            extra_link_args=['-std=c++11'],
+        ),
+        Extension(
+            'meeteval.wer.matching.cy_greedy_combination_matching',
+            ['meeteval/wer/matching/cy_greedy_combination_matching.pyx'],
             extra_compile_args=['-std=c++11', '-O3'],
             extra_link_args=['-std=c++11'],
         ),
@@ -131,5 +137,6 @@ setup(
             'meeteval-wer=meeteval.wer.__main__:cli',
             'meeteval-der=meeteval.der.__main__:cli',
         ]
-    }
+    },
+    include_dirs=[numpy.get_include()],
 )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -81,18 +81,37 @@ def test_burn_orc():
     run('python -m meeteval.wer orcwer -h hyp.stm -r ref.stm --reference-sort "segment" --hypothesis-sort "false"')
 
 
+def test_burn_greedy_orc():
+    # Normal test with stm files
+    run(f'python -m meeteval.wer greedy_orcwer -h hyp.stm -r ref.stm')
+    run(f'meeteval-wer greedy_orcwer -h hyp.stm -r ref.stm')
+
+    # Test sort option. Only test the ones that are available for ORC
+    run('python -m meeteval.wer greedy_orcwer -h hyp.stm -r ref.stm --reference-sort "segment" --hypothesis-sort "false"')
+
+    # Test distancetype option
+    run(f'meeteval-wer greedy_orcwer -h hyp.stm -r ref.stm --distancetype 1')
+    run(f'meeteval-wer greedy_orcwer -h hyp.stm -r ref.stm --distancetype 2')
+    run(f'meeteval-wer greedy_orcwer -h hyp.stm -r ref.stm --distancetype 21')
+
+    # Test assignment initialization
+    run(f'meeteval-wer greedy_orcwer -h hyp.stm -r ref.stm --assignment-initialization random')
+    run(f'meeteval-wer greedy_orcwer -h hyp.stm -r ref.stm --assignment-initialization constant')
+
+
+
 def test_burn_mimo():
     run(f'python -m meeteval.wer mimower -h hyp.stm -r ref.stm')
     run(f"python -m meeteval.wer mimower -h 'hyp?.stm' -r 'ref?.stm'")
     run(f'python -m meeteval.wer mimower -h hyp.seglst.json -r ref.seglst.json')
-    run('python -m meeteval.wer orcwer -h hyp.stm -r ref.stm --reference-sort "segment" --hypothesis-sort "false"')
+    run('python -m meeteval.wer mimower -h hyp.stm -r ref.stm --reference-sort "segment" --hypothesis-sort "false"')
 
 
 def test_burn_cp():
     run(f'python -m meeteval.wer cpwer -h hyp.stm -r ref.stm')
     run(f"python -m meeteval.wer cpwer -h 'hyp?.stm' -r 'ref?.stm'")
     run(f'python -m meeteval.wer cpwer -h hyp.seglst.json -r ref.seglst.json')
-    run('python -m meeteval.wer orcwer -h hyp.stm -r ref.stm --reference-sort "segment" --hypothesis-sort "false"')
+    run('python -m meeteval.wer cpwer -h hyp.stm -r ref.stm --reference-sort "segment" --hypothesis-sort "false"')
     run(f'python -m meeteval.wer cpwer -h hyp.stm -r ref.stm --uem uem.uem')
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -89,11 +89,6 @@ def test_burn_greedy_orc():
     # Test sort option. Only test the ones that are available for ORC
     run('python -m meeteval.wer greedy_orcwer -h hyp.stm -r ref.stm --reference-sort "segment" --hypothesis-sort "false"')
 
-    # Test distancetype option
-    run(f'meeteval-wer greedy_orcwer -h hyp.stm -r ref.stm --distancetype 1')
-    run(f'meeteval-wer greedy_orcwer -h hyp.stm -r ref.stm --distancetype 2')
-    run(f'meeteval-wer greedy_orcwer -h hyp.stm -r ref.stm --distancetype 21')
-
     # Test assignment initialization
     run(f'meeteval-wer greedy_orcwer -h hyp.stm -r ref.stm --assignment-initialization random')
     run(f'meeteval-wer greedy_orcwer -h hyp.stm -r ref.stm --assignment-initialization constant')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -89,11 +89,6 @@ def test_burn_greedy_orc():
     # Test sort option. Only test the ones that are available for ORC
     run('python -m meeteval.wer greedy_orcwer -h hyp.stm -r ref.stm --reference-sort "segment" --hypothesis-sort "false"')
 
-    # Test assignment initialization
-    run(f'meeteval-wer greedy_orcwer -h hyp.stm -r ref.stm --assignment-initialization random')
-    run(f'meeteval-wer greedy_orcwer -h hyp.stm -r ref.stm --assignment-initialization constant')
-
-
 
 def test_burn_mimo():
     run(f'python -m meeteval.wer mimower -h hyp.stm -r ref.stm')

--- a/tests/test_greedy_combination_matching.py
+++ b/tests/test_greedy_combination_matching.py
@@ -1,9 +1,13 @@
+from pathlib import Path
+
 import pytest
 import time
 
 from meeteval.wer.matching import greedy_combination_matching, orc_matching
 import meeteval
 from hypothesis import given, strategies as st, settings, assume
+
+example_files = (Path(__file__).parent.parent / 'example_files').absolute()
 
 # Set up hypothesis strategies
 # Limit alphabet to ensure a few correct matches. Every character represents
@@ -43,3 +47,33 @@ def test_greedy_bound_by_optimal(segments, streams):
     optimal_distance, _ = orc_matching.orc_matching_v3(segments, streams)
 
     assert optimal_distance <= greedy_distance
+
+
+def test_example_files_orc_equals_greedy_orc():
+    optimal_result = meeteval.wer.orcwer(example_files / 'ref.stm', example_files / 'hyp.stm')
+    greedy_result = meeteval.wer.greedy_orcwer(example_files / 'ref.stm', example_files / 'hyp.stm')
+
+    assert optimal_result == greedy_result
+
+
+@given(segments(10), streams(4), st.sampled_from(['1', '21']))
+def test_optimal_assignment_is_not_changed(segments, streams, distancetype):
+    """
+    Test that the optimal assignment is not changed.
+
+    Only works with distancetype='1'. The optimal ORC assignment is not
+    guaranteed to be optimal for other substitution costs than 1.
+    For distanctype='21' we can at least guarantee that the greedily corrected
+    assignment is not worse than the optimal assignment, but we cannot guarantee
+    equality.
+    """
+    optimal_distance, optimal_assignment = orc_matching.orc_matching_v3(segments, streams)
+
+    greedy_distance, greedy_assignment = greedy_combination_matching.greedy_combination_matching(
+        segments, streams, optimal_assignment,
+        distancetype=distancetype,
+    )
+
+    assert optimal_distance == greedy_distance
+    if distancetype == '1':
+        assert optimal_assignment == greedy_assignment

--- a/tests/test_greedy_combination_matching.py
+++ b/tests/test_greedy_combination_matching.py
@@ -50,30 +50,26 @@ def test_greedy_bound_by_optimal(segments, streams):
 
 
 def test_example_files_orc_equals_greedy_orc():
-    optimal_result = meeteval.wer.orcwer(example_files / 'ref.stm', example_files / 'hyp.stm')
-    greedy_result = meeteval.wer.greedy_orcwer(example_files / 'ref.stm', example_files / 'hyp.stm')
+    optimal_result = meeteval.wer.orcwer(example_files / 'ref?.stm', example_files / 'hyp?.stm')
+    greedy_result = meeteval.wer.greedy_orcwer(example_files / 'ref?.stm', example_files / 'hyp?.stm')
 
     assert optimal_result == greedy_result
 
 
-@given(segments(10), streams(4), st.sampled_from(['1', '21']))
-def test_optimal_assignment_is_not_changed(segments, streams, distancetype):
+@given(segments(10), streams(4))
+def test_optimal_assignment_is_not_changed(segments, streams):
     """
     Test that the optimal assignment is not changed.
 
     Only works with distancetype='1'. The optimal ORC assignment is not
-    guaranteed to be optimal for other substitution costs than 1.
-    For distanctype='21' we can at least guarantee that the greedily corrected
-    assignment is not worse than the optimal assignment, but we cannot guarantee
-    equality.
+    guaranteed to be optimal for substitution costs other than 1.
     """
     optimal_distance, optimal_assignment = orc_matching.orc_matching_v3(segments, streams)
 
     greedy_distance, greedy_assignment = greedy_combination_matching.greedy_combination_matching(
         segments, streams, optimal_assignment,
-        distancetype=distancetype,
+        distancetype='1',
     )
 
     assert optimal_distance == greedy_distance
-    if distancetype == '1':
-        assert optimal_assignment == greedy_assignment
+    assert optimal_assignment == greedy_assignment

--- a/tests/test_greedy_combination_matching.py
+++ b/tests/test_greedy_combination_matching.py
@@ -1,0 +1,45 @@
+import pytest
+import time
+
+from meeteval.wer.matching import greedy_combination_matching, orc_matching
+import meeteval
+from hypothesis import given, strategies as st, settings, assume
+
+# Set up hypothesis strategies
+# Limit alphabet to ensure a few correct matches. Every character represents
+# a word
+utterance = st.lists(st.integers(min_value=0, max_value=10), max_size=10)
+segments = lambda max_size: st.lists(utterance, min_size=0, max_size=max_size)
+streams = lambda max_size: st.lists(utterance, min_size=1, max_size=max_size)
+
+
+def _check_output(distance, assignment, segments, streams):
+    assert isinstance(distance, int)
+    assert distance >= 0
+    assert len(assignment) == len(segments)
+    assert all(isinstance(a, int) for a in assignment)
+    assert all(0 <= a < len(streams) for a in assignment)
+    d = orc_matching._levensthein_distance_for_assignment(segments, streams, assignment)
+    assert d == distance, (d, distance, assignment)
+
+
+@given(segments(10), streams(4))
+@settings(deadline=None)  # The tests take longer on the GitHub actions test servers
+def test_greedy_combination_matching_burn(segments, streams):
+    """Burn-test. Brute-force is exponential in the number of reference
+    utterances, so choose a small number."""
+    distance, assignment = greedy_combination_matching.greedy_combination_matching(
+        segments, streams, [0] * len(segments)
+    )
+    _check_output(distance, assignment, segments, streams)
+
+
+@given(segments(6), streams(4))
+def test_greedy_bound_by_optimal(segments, streams):
+    greedy_distance, _ = greedy_combination_matching.greedy_combination_matching(
+        segments, streams, [0] * len(segments)
+    )
+
+    optimal_distance, _ = orc_matching.orc_matching_v3(segments, streams)
+
+    assert optimal_distance <= greedy_distance


### PR DESCRIPTION
This PR adds the core greedy algorithm and the wrappers for ORC WER. I will add other pull requests for the time-constrained greedy algorithm and the DI-cpWER when this is merged.

I named it "greedy combination matching", similar to the "optimal combination matching" acronym from the ORC WER. Given this naming, I'm unsure if the name "greedy ORC-WER" fits well because it mixes the terms "greedy" and "optimal". But, at the same time, the term ORC-WER is already known, and greedy ORC seems clearer to me.

I did not use "reference" and "hypothesis" but "segments" and "streams" so that the core code can be used for both ORC-WER and DI-cpWER without name conflicts.