### PR TITLE
Various minor improvements to the visualization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ example_files/viz
 !example_files/*.seglst.json
 
 # Created by pyodide
-.pyodide-xbuildenv
+.pyodide-xbuildenv*
 
 # Downloaded by the md_eval wrapper
 meeteval/der/md-eval-22.pl

--- a/meeteval/viz/visualize.css
+++ b/meeteval/viz/visualize.css
@@ -440,6 +440,18 @@ wer table */
     touch-action: manipulation;
 }
 
+.search-bar button:disabled {
+    background-color: #ccc;
+    color: #666;
+    cursor: default;
+}
+
+/* Make italic and gray*/
+.search-bar .match-number {
+    /* font-style: italic; */
+    color: gray;
+}
+
 .clickable {
     cursor: pointer;
     text-decoration: underline;

--- a/meeteval/viz/visualize.css
+++ b/meeteval/viz/visualize.css
@@ -119,6 +119,10 @@ code {
     flex-wrap: wrap;
 }
 
+audio.info-value {
+    height: 1.5em;
+}
+
 .legend-element {
     margin: 0 3px 0 3px;
     padding: 0 0px 0 0;
@@ -162,6 +166,21 @@ i, .icon {
 
 .copybutton i {
     margin-right: 0px;
+}
+
+/* Make copy button same height as text in the details preview and hide any fancy formatting.
+This prevents the view from jumping when a segment is selected*/
+.info-value .copybutton {
+    height: 1em;
+    padding: 0 5px;
+    margin: 0;
+    border: none;
+}
+
+.info-value .copybutton i {
+    margin-right: 0px;
+    height: 1em;
+    font-size: .75em;
 }
 
 /* Plot elements */

--- a/meeteval/viz/visualize.css
+++ b/meeteval/viz/visualize.css
@@ -133,6 +133,7 @@ audio.info-value {
     display: inline-block;
     width: 10px;
     height: 10px;
+    border: 1px solid #aaa;
 }
 
 .legend-label {

--- a/meeteval/viz/visualize.js
+++ b/meeteval/viz/visualize.js
@@ -5,7 +5,7 @@ var colormaps = {
         'insertion': '#33c2f5', // blue
         'deletion': '#f2beb1',  // red
         // 'ignored': 'transparent',   // purple
-        'highlight': 'green'
+        'highlight': 'yellow'
     },
     diff: {
         'correct': 'lightgray',
@@ -1894,24 +1894,35 @@ class CanvasPlot {
                 // considering overlaps with other utterances
                 const utterance = this.utterances[d['utterance_index']];
 
-                // Fill the box with the color of the match
-                if (d.matches?.length > 0 || d.highlight) {
-                    context.beginPath();
-                    context.rect(
-                        utterance.x,
-                        this.plot.y(d.start_time),
-                        utterance.width,
-                        this.plot.y(d.end_time) - this.plot.y(d.start_time));
+                // Draw word boxes
+                context.beginPath();
+                context.rect(
+                    utterance.x,
+                    this.plot.y(d.start_time),
+                    utterance.width,
+                    this.plot.y(d.end_time) - this.plot.y(d.start_time)
+                );
 
-                    if (d.highlight) context.fillStyle = settings.colors.highlight;
-                    else context.fillStyle = settings.colors[d.matches[0][1]];
+                // Fill box with match color
+                if (d.matches?.length > 0) {
+                    context.fillStyle = settings.colors[d.matches[0][1]];
+                    context.fill();
+
+                    // Draw box border
+                    context.strokeStyle = "gray";
+                    context.lineWidth = 2;
+                    if (draw_boxes) context.stroke();
                 }
-                context.fill();
-
-                // Draw box border
-                context.strokeStyle = "gray";
-                context.lineWidth = 2;
-                if (draw_boxes) context.stroke();
+                
+                // Draw inner box border with highlight color
+                if (d.highlight){
+                    context.save();
+                    context.clip(); // Clip to the box so that it doesn't overlap with other words
+                    context.strokeStyle = settings.colors.highlight;
+                    context.lineWidth = 20;
+                    context.stroke();
+                    context.restore();
+                }
 
                 // Draw (stub) stitches for insertion / deletion
                 // These do not connect to other words, but are drawn as a straight line

--- a/meeteval/viz/visualize.js
+++ b/meeteval/viz/visualize.js
@@ -2067,7 +2067,10 @@ class CanvasPlot {
             });
             this.update(null);
 
-            this.blacklist = ["source", "session_id"]
+            this.blacklist = [
+                "source", "session_id", "utterance_index", "utterance_overlaps", 
+                "overlap_width", "overlap_shift", "num_columns", "x", "width", "highlight"
+            ];
             this.rename = { total: "# words" }
         }
 

--- a/meeteval/viz/visualize.js
+++ b/meeteval/viz/visualize.js
@@ -484,6 +484,7 @@ function alignment_visualization(
         return Math.sin((x * Math.PI) / 2);
     }
 
+    let animationIntervalID = null;
     function animateToViewArea(i, viewArea) {
         // Animate view area to the location of the segment.
         // The animation plays for 4 steps over 80ms.
@@ -493,7 +494,7 @@ function alignment_visualization(
         // easily lose track of the position.
         const target_location = viewArea;
         const start_location = state.viewAreas[i];
-
+        clearInterval(animationIntervalID);
         let j = 0;
         const step = () => {
             j += 0.25;
@@ -501,10 +502,10 @@ function alignment_visualization(
             const a = easeOutSine(j);
             setViewArea(i, [start_location[0] * (1 - a) + target_location[0]*a, start_location[1] * (1 - a) + target_location[1]*a]); 
             update();
-            if (j == 1) clearInterval(intervalID);
+            if (j == 1) clearInterval(animationIntervalID);
         };
         // 20ms is the throttling interval for update()
-        let intervalID = setInterval(step, 20);
+        animationIntervalID = setInterval(step, 20);
         step(); // Do first update immediately for instant feedback
     }
 
@@ -2428,4 +2429,21 @@ class CanvasPlot {
 
     rebuild();
     searchBar.search_button.node().click();
+
+    function moveBy(offset) {
+        animateToViewArea(state.viewAreas.length - 1, [state.viewAreas[state.viewAreas.length - 1][0] + offset, state.viewAreas[state.viewAreas.length - 1][1] + offset]);
+    }
+
+    // Register keyboard handler
+    document.addEventListener("keydown", (event) => {
+        switch (event.key) {
+            case "Escape": selectSegment(null); break;
+            // Scroll by 10% of the currently visible range for ArrowUp and ArrowDown. A constant quickly feels too fast or too slow depending on the zoom level.
+            case "ArrowUp": moveBy((state.viewAreas[state.viewAreas.length - 1][0] - state.viewAreas[state.viewAreas.length - 1][1]) / 10); break;
+            case "ArrowDown": moveBy(-(state.viewAreas[state.viewAreas.length - 1][0] - state.viewAreas[state.viewAreas.length - 1][1]) / 10); break;
+            // Scroll by the currently visible range for PageUP and PageDown
+            case "PageUp": moveBy(state.viewAreas[state.viewAreas.length - 1][0] - state.viewAreas[state.viewAreas.length - 1][1]); break;
+            case "PageDown": moveBy(state.viewAreas[state.viewAreas.length - 1][1] - state.viewAreas[state.viewAreas.length - 1][0]); break;
+        }
+    });
 }

--- a/meeteval/viz/visualize.js
+++ b/meeteval/viz/visualize.js
@@ -2021,11 +2021,25 @@ class CanvasPlot {
                 context.fillStyle = "gray";
                 context.textAlign = "center";
                 context.textBaseline = "bottom";
-                context.fillText(`begin time: ${d.start_time.toFixed(2)}`, d.x + d.width / 2, this.plot.y(d.start_time) - 3);
+                {
+                    const text = `begin time: ${d.start_time.toFixed(2)}`;
+                    const textMetrics = context.measureText(text);
+                    context.fillStyle = "#eee";
+                    context.fillRect(d.x + d.width / 2 - textMetrics.width / 2 - 3, this.plot.y(d.start_time), textMetrics.width + 6, - (textMetrics.fontBoundingBoxAscent + textMetrics.fontBoundingBoxDescent));
+                    context.fillStyle = "gray";
+                    context.fillText(text, d.x + d.width / 2, this.plot.y(d.start_time) - 1);
+                }
 
                 // Write end time below end marker
-                context.textBaseline = "top";
-                context.fillText(`end time: ${d.end_time.toFixed(2)}`, d.x + d.width / 2, this.plot.y(d.end_time) + 3);
+                {
+                    context.textBaseline = "top";
+                    const text = `end time: ${d.end_time.toFixed(2)}`;
+                    const textMetrics = context.measureText(text);
+                    context.fillStyle = "#eee";
+                    context.fillRect(d.x + d.width / 2 - textMetrics.width / 2 - 3, this.plot.y(d.end_time), textMetrics.width + 6, (textMetrics.fontBoundingBoxAscent + textMetrics.fontBoundingBoxDescent));
+                    context.fillStyle = "gray";
+                    context.fillText(`end time: ${d.end_time.toFixed(2)}`, d.x + d.width / 2, this.plot.y(d.end_time) + 2);
+                }
             }
         }
 

--- a/meeteval/viz/visualize.py
+++ b/meeteval/viz/visualize.py
@@ -275,6 +275,10 @@ def get_visualization_data(ref: SegLST, hyp: SegLST, assignment='tcp', alignment
         }
     }
 
+    # Add original speaker/stream label
+    ref = ref.map(lambda s: {**s, 'stream': s['speaker']})
+    hyp = hyp.map(lambda s: {**s, 'stream': s['speaker']})
+
     # Get and apply stream assignment
     wer, ref, hyp = solve_stream_assignment(ref, hyp, assignment)
     align_type = 'time_constrained' if assignment in ['tcp', 'tcorc'] else 'levenshtein'

--- a/scripts/build_pyodide_wheel.sh
+++ b/scripts/build_pyodide_wheel.sh
@@ -1,0 +1,25 @@
+PYODIDE_FOLDER=build/pyodide
+
+workdir=$(pwd)
+
+# Clone pyodide if not present
+if [ ! -d $PYODIDE_FOLDER ]; then
+    git clone https://github.com/pyodide/pyodide.git $PYODIDE_FOLDER
+fi
+
+# Build patched version of emsdk
+cd $PYODIDE_FOLDER/emsdk
+make
+
+# Install pyodide-build (and pyodide-cli) in the current environment
+# We know that pyodide-build==0.28.0 works, earlier versions may not work
+pip install pyodide-build>=0.28.0
+
+# Source the environment
+PYODIDE_EMSCRIPTEN_VERSION=$(pyodide config get emscripten_version)
+./emsdk install ${PYODIDE_EMSCRIPTEN_VERSION}
+./emsdk activate ${PYODIDE_EMSCRIPTEN_VERSION}
+source emsdk_env.sh
+
+cd $workdir
+pyodide build


### PR DESCRIPTION
- Adds buttons to jump to the previous/next match to the search box
- Remove internal keys from the details view
- Display the original stream label from the input files (before applying the assignment) in the details table
- Add a timeout for opening the tooltip to prevent opening it accidentally. This is especially useful for the large details tooltip that may cover a large area of the plots
- Make the audio player and copy button smaller in the collapsed details view so that the views don't jump when an audio player is displayed
- Animate drastic view changes, like jumping to the next search match
- Improve rendering of the begin time and end time markers
- Improve rendering of search highlights
- Move view area to segment/utterance on double click