### PR TITLE
Fix orc assignment empty segments

### DIFF
--- a/meeteval/io/seglst.py
+++ b/meeteval/io/seglst.py
@@ -509,6 +509,7 @@ def groupby(
 
     groups = collections.defaultdict(list)
     try:
+        # This keeps the order of the keys
         for key, group in itertools.groupby(iterable, _get_key(key)):
             groups[key].extend(group)
     except KeyError:

--- a/meeteval/wer/wer/orc.py
+++ b/meeteval/wer/wer/orc.py
@@ -135,11 +135,13 @@ def _orc_error_rate(
     if len(assignment) != total_num_segments:
         # Make sure this assignment is reproducible by sorting the keys
         dummy_key = sorted(hypothesis_keys)[0]
-        assignment = sorted([(r['segment_index'], a) for a, r in zip(assignment, reference)])
+        assignment = sorted([(r, a) for a, r in zip(assignment, sorted(set(reference.unique('segment_index'))))])
         for i in range(total_num_segments):
             if i >= len(assignment) or assignment[i][0] != i:
                 assignment.insert(i, (i, dummy_key))
         assignment = [a[1] for a in assignment]
+
+        assert len(assignment) == total_num_segments, (len(assignment), total_num_segments)
 
     return OrcErrorRate(
         er.errors, er.length,
@@ -287,7 +289,6 @@ def apply_orc_assignment(
                 reference = reference.groupby('segment_index').values()
             else:
                 reference = [[r] for r in reference]
-
             assert len(reference) == len(assignment), (len(reference), len(assignment))
             reference = meeteval.io.SegLST([
                 {**s, 'speaker': a}

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -110,6 +110,7 @@ def exec_with_source(code, filename, lineno, globals_=None, locals_=None):
         [
             (str(filename.relative_to(MEETEVAL_ROOT)), codeblock)
             for filename in MEETEVAL_ROOT.glob('**/*.md')
+            if 'build' not in str(filename) and '/.' not in str(filename)
             for codeblock in get_fenced_code_blocks(filename.read_text())
         ]
 )

--- a/tests/test_time_constrained_orc_matching.py
+++ b/tests/test_time_constrained_orc_matching.py
@@ -44,7 +44,7 @@ def seglst(draw, min_segments=0, max_segments=10, max_speakers=2):
 
 @given(
     seglst(max_speakers=1, min_segments=1),
-    seglst(max_speakers=2, min_segments=1)
+    seglst(max_speakers=3, min_segments=1)
 )
 @settings(deadline=None)    # The tests take longer on the GitHub actions test servers
 def test_tcorc_burn(reference, hypothesis):

--- a/tests/test_time_constrained_orc_matching.py
+++ b/tests/test_time_constrained_orc_matching.py
@@ -158,7 +158,7 @@ def test_examples_zero_self_overlap():
 
 def test_assignment_keeps_order():
     """
-    Tests that elements in the assignment corrspond to the order in the input
+    Tests that elements in the assignment correspond to the order in the input
     to the orc_wer function, not the sorted segments.
     """
     from meeteval.wer.wer.time_constrained_orc import time_constrained_orc_wer
@@ -175,6 +175,6 @@ def test_assignment_keeps_order():
         ]),
         reference_sort='segment',
     )
-    assert tcorc.assignment == ('A1', 'A1', 'A2')
+    assert tcorc.assignment == ('A1', 'A1', 'A2'), tcorc.assignment
 
 

--- a/tests/test_time_constrained_orc_matching.py
+++ b/tests/test_time_constrained_orc_matching.py
@@ -48,8 +48,6 @@ def seglst(draw, min_segments=0, max_segments=10, max_speakers=2):
 )
 @settings(deadline=None)    # The tests take longer on the GitHub actions test servers
 def test_tcorc_burn(reference, hypothesis):
-    """Burn-test. Brute-force is exponential in the number of reference
-    utterances, so choose a small number."""
     from meeteval.wer.wer.time_constrained_orc import time_constrained_orc_wer
 
     tcorc = time_constrained_orc_wer(reference, hypothesis, collar=1000, reference_sort=False, hypothesis_sort=False)


### PR DESCRIPTION
Fix the ORC assignment for empty segments.

This has no effect on the WER, only on the assignment, which sometimes had the wrong length when empty segments (`words=''`) were present.