### PR TITLE
Improve Visualization

### DIFF
--- a/meeteval/der/__main__.py
+++ b/meeteval/der/__main__.py
@@ -11,6 +11,9 @@ def md_eval_22(
         regex=None,
         uem=None,
 ):
+    """
+    Computes the Diarization Error Rate (DER) using md-eval-22.pl.
+    """
     from meeteval.der.api import md_eval_22
     results = md_eval_22(
         reference,

--- a/meeteval/der/md_eval.py
+++ b/meeteval/der/md_eval.py
@@ -201,6 +201,9 @@ def md_eval_22_multifile(
 
 
 def md_eval_22(reference, hypothesis, collar=0, regions='all', uem=None):
+    """
+    Computes the Diarization Error Rate (DER) using md-eval-22.pl.
+    """
     from meeteval.io.rttm import RTTM
     reference = RTTM.new(reference, filename='dummy')
     hypothesis = RTTM.new(hypothesis, filename='dummy')

--- a/meeteval/viz/__main__.py
+++ b/meeteval/viz/__main__.py
@@ -312,6 +312,8 @@ def cli():
                     help='Specifies which assigment and alignment are used. If a time-constrained algorithm is '
                          'selected for the stream assignment, then a time-constrained alignment will be computed, '
                          'otherwise the "classical" alignment without a time constraint is used.\n'
+                         'Multiple alignments can be specified to generate multiple visualizations with a single '
+                         'merged overview table and side-by-side views.\n'
                          'Choices:\n'
                          '- cp: cpWER and "classical" alignment\n'
                          '- tcp: tcpWER and time-constrained alignment\n'
@@ -341,7 +343,9 @@ def cli():
                 command_parser.add_argument(
                     '--per-reco-file',
                     help='A precomputed per-reco file. Loads the WER and (stream) '
-                         'assignment information from this file instead of computing it.',
+                         'assignment information from this file instead of computing it. '
+                         'If supplied, the number of files must match the number of alignments specified '
+                         'with --alignment.',
                     default=None,
                     nargs='+',
                 )

--- a/meeteval/viz/__main__.py
+++ b/meeteval/viz/__main__.py
@@ -307,10 +307,20 @@ def cli():
             if name == 'alignment':
                 command_parser.add_argument(
                     '--alignment',
-                    choices=['tcp', 'cp', 'tcp,cp', 'cp,tcp', 'tcorc', 'orc'],
-                    help='Specifies which alignment is used.\n'
-                         '- cp: Find the permutation that minimizes the cpWER and use the "classical" alignment.\n'
-                         '- tcp: Find the permutation that minimizes the tcpWER and use a time constraint alignment.'
+                    choices=['tcp', 'cp', 'orc', 'greedy_orc', 'tcorc', 'greedy_tcorc', 'greedy_dicp', 'greedy_ditcp'],
+                    nargs='+',
+                    help='Specifies which assigment and alignment are used. If a time-constrained algorithm is '
+                         'selected for the stream assignment, then a time-constrained alignment will be computed, '
+                         'otherwise the "classical" alignment without a time constraint is used.\n'
+                         'Choices:\n'
+                         '- cp: cpWER and "classical" alignment\n'
+                         '- tcp: tcpWER and time-constrained alignment\n'
+                         '- orc: ORC-WER and "classical" alignment.\n'
+                         '- greedy_orc: greedy ORC-WER and "classical" alignment.\n'
+                         '- tcorc: tcORC-WER and time-constrained alignment.\n'
+                         '- greedy_tcorc: greedy tcORC-WER.\n'
+                         '- greedy_dicp: greedy DI-cpWER and "classical" alignment.\n'
+                         '- greedy_ditcp: greedy DI-tcpWER and time-constrained alignment.',
                 )
             elif name == 'hypothesis':
                 command_parser.add_argument(

--- a/meeteval/viz/__main__.py
+++ b/meeteval/viz/__main__.py
@@ -250,6 +250,21 @@ def html(
         js_debug=False,
         per_reco_file=None,
 ):
+    """
+    Creates a visualization of the alignment between reference and hypothesis for the specified WER algorithm.
+
+    The visualization is created in two steps.
+    
+    First, compute the WER and assignment, i.e. the mapping of utterances/segments to streams. Any WER algorithm 
+    from meeteval can be used for this. Depending on the algorithm, the labels of the reference or 
+    hypothesis utterances or streams are modified.
+
+    
+    
+    Second, compute the alignment, i.e. the matching of words between reference and hypothesis (insertion, 
+    deletion, substitution). This is done with a time-constrained algorithm if the assignment was 
+    time-constrained, otherwise with a "classical" unconstrained algorithm.
+    """
     def prepare(i: int, h: str):
         if ':' in h and not Path(h).exists():
             # inspired by tensorboard from the --logdir_spec argument.
@@ -291,20 +306,9 @@ def cli():
                     '--alignment',
                     choices=['tcp', 'cp', 'orc', 'greedy_orc', 'tcorc', 'greedy_tcorc', 'greedy_dicp', 'greedy_ditcp'],
                     nargs='+',
-                    help='Specifies which assigment and alignment are used. If a time-constrained algorithm is '
-                         'selected for the stream assignment, then a time-constrained alignment will be computed, '
-                         'otherwise the "classical" alignment without a time constraint is used.\n'
+                    help='Specifies the algorithm used to obtain the alignment. \n'
                          'Multiple alignments can be specified to generate multiple visualizations with a single '
-                         'merged overview table and side-by-side views.\n'
-                         'Choices:\n'
-                         '- cp: cpWER and "classical" alignment\n'
-                         '- tcp: tcpWER and time-constrained alignment\n'
-                         '- orc: ORC-WER and "classical" alignment.\n'
-                         '- greedy_orc: greedy ORC-WER and "classical" alignment.\n'
-                         '- tcorc: tcORC-WER and time-constrained alignment.\n'
-                         '- greedy_tcorc: greedy tcORC-WER.\n'
-                         '- greedy_dicp: greedy DI-cpWER and "classical" alignment.\n'
-                         '- greedy_ditcp: greedy DI-tcpWER and time-constrained alignment.',
+                         'merged overview table and side-by-side views.'
                 )
             elif name == 'hypothesis':
                 command_parser.add_argument(

--- a/meeteval/viz/__main__.py
+++ b/meeteval/viz/__main__.py
@@ -96,24 +96,6 @@ def create_viz_folder(
             avs_T[session_id][i] = av
     avs_T = dict(avs_T)
 
-    for session_id, v in avs_T.items():
-        doc, tag, text = Doc().tagtext()
-        doc.asis('<!DOCTYPE html>')
-
-        # With 100 % there is a scroll bar -> use 99 %
-        with tag('html', style="height: 99%; margin: 0;"):
-            with tag('body', style="width: 100%; height: 100%; margin: 0; display: flex;"):
-                for (i, alignment), av in v.items():
-                    with tag('div', style='flex-grow: 1'):
-                        with tag('iframe', src=f'{session_id}_{i}_{alignment}.html',
-                                 title="right", width="100%",
-                                 height="100%", style="border-width: 0"):
-                            pass
-
-        file = out / f"{session_id}.html"
-        file.write_text(indent(doc.getvalue()))
-        print(f'Wrote file://{file.absolute()}')
-
     ###########################################################################
 
     from yattag import Doc
@@ -214,12 +196,9 @@ def create_viz_folder(
 
                             if len(v) > 1:
                                 with tag('td'):
-                                    with tag('a', href=f'{session_id}.html'):
-                                        doc.text('SideBySide')
-                                with tag('td'):
-                                    tags = '&'.join(f'{session_id}_{i}_{a}' for i, a in v.keys())
+                                    tags = '&'.join(f'{session_id}_{i}_{a}.html' for i, a in v.keys())
                                     with tag('a', href=f'side_by_side_sync.html?{tags}'):
-                                        doc.text('SydeBySide Synced')
+                                        doc.text('SydeBySide')
             doc.asis('''
 <script>
     $(document).ready(function() {

--- a/meeteval/viz/__main__.py
+++ b/meeteval/viz/__main__.py
@@ -21,7 +21,6 @@ def create_viz_folder(
     out = Path(out)
     out.mkdir(parents=True, exist_ok=True)
 
-
     if isinstance(alignments, str):
         alignments = alignments.split(',')
 
@@ -33,6 +32,10 @@ def create_viz_folder(
             'cp': meeteval.wer.CPErrorRate,
             'tcorc': meeteval.wer.OrcErrorRate,
             'orc': meeteval.wer.OrcErrorRate,
+            'greedy_orc': meeteval.wer.OrcErrorRate,
+            'greedy_tcorc': meeteval.wer.OrcErrorRate,
+            'greedy_dicp': meeteval.wer.DICPErrorRate,
+            'greedy_ditcp': meeteval.wer.DICPErrorRate,
         }
 
         def load_per_reco_file(alignment, f):

--- a/meeteval/viz/side_by_side_sync.html
+++ b/meeteval/viz/side_by_side_sync.html
@@ -1,46 +1,151 @@
 
 <!DOCTYPE html>
-<html style="height:99%; margin: 0;">
+<html style="height: 100%; margin: 0;">
+  <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <title>MeetEval: Side by side view</title>
+      <style>
+          .container {
+              display: flex;
+              max-width: 100%;
+              white-space: nowrap; /* Prevent wrapping and hide overflowing content. */
+              overflow-x: auto; /* Enable horizontal scrolling */
+              white-space: nowrap; /* Prevent line breaks within the container */
+              height: 100%;
+              width:100%;
+              flex-direction: column;
+
+          }
+          .breadcrumb-container {
+              display: inline-flex;
+              justify-content: flex-end;
+              overflow: hidden;
+              max-width: min-content;
+          }
+          .breadcrumb {
+             font-family: Arial, sans-serif;
+             background-color: #f9f9f9;
+              align-items: center;
+              padding: 2px 10px;
+              background-color: #fff;
+              box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+              border-radius: 6px;
+              font-size: 14px; /* Smaller font size */
+          }
+          .breadcrumb a {
+              color: #3498db;
+              text-decoration: none;
+              padding: 4px 8px; /* Reduced padding for tighter layout */
+              border-radius: 4px;
+              transition: background-color 0.3s;
+          }
+          .breadcrumb a:hover {
+              background-color: #3498db;
+              color: #fff;
+          }
+          .breadcrumb span {
+              margin: 0 3px; /* Smaller spacing between arrows and links */
+              color: #555;
+          }
+
+          iframe {
+              width: 100%;
+              flex-grow: 1;
+              border: none;
+          }
+      </style>
+  </head>
   <body style="width: 100%; height: 100%; margin: 0; display: flex;">
   </body>
 
 <script>
+     function createBreadcrumb(url, container, iframe) {
+       container.className = 'breadcrumb-container';
+       const breadcrumbContainer = document.createElement('div');
+         breadcrumbContainer.className = 'breadcrumb';
+            container.append(breadcrumbContainer);
+        const urlObj = new URL(url);  // Create a URL object
+        const parts = urlObj.pathname.split('/').filter(Boolean);  // Get path parts and filter out empty strings
+        let accumulatedPath = urlObj.origin;  // Start with the base URL (origin)
+
+        // Add 'Home' link
+        breadcrumbContainer.innerHTML += `<a href="${accumulatedPath}">/</a>`;
+
+        // Add a click event listener to the breadcrumb container
+        breadcrumbContainer.addEventListener('click', function(event) {
+          // Check if the clicked element is a link
+          if (event.target.tagName === 'A') {
+            event.preventDefault();  // Prevent default link navigation
+
+            const newSrc = event.target.getAttribute('href');  // Get the href of the clicked link
+
+            iframe.src = newSrc;  // Change the iframe's source
+          }
+        });
+
+        // Loop through each folder and create a link
+        parts.forEach((part, index) => {
+            accumulatedPath += `/${part}`;
+            breadcrumbContainer.innerHTML += `<span>&#187;</span><a href="${accumulatedPath}">${part}</a>`;
+        });
+    }
+
     var urlParams = new URLSearchParams(window.location.search);
     const iframes = []
+    const breadcrumbs = []
     const body = document.getElementsByTagName('body')[0];
     var sync = true;
+    const new_url_params = [];
+    const other_new_url_params = {};
     urlParams.forEach((value, key) => {
       if (!value) {
         // Value is none when no key is given (e.g., ?systemA&systemB vs ?sync=True)
         value = key;
 
-        // Preprocess file path
-        if (!value.endsWith('.html') && !value.endsWith('.htm')) {
-            value += '.html';
-        }
         const iframe = document.createElement('iframe');
         iframe.src = value;
-        iframe.width = "100%";
-        iframe.height = "100%";
-        iframe.style.border = "none";
         iframes.push(iframe);
         const div = document.createElement('div')
-        div.style = "flex-grow: 1;";
-        div.append(iframe)
+        div.className = 'container';
+        const breadcrumbContainer = document.createElement('div');
+        div.append(breadcrumbContainer);
+        breadcrumbs.push(breadcrumbContainer);
+        console.log(value);
+        createBreadcrumb('file://' + value, breadcrumbContainer, iframe);
+        div.append(iframe);
         body.append(div);
+        new_url_params.push(value);
       } else if (key === "sync") {
         sync = value === "true";
+        other_new_url_params[key] = value;
       }
     })
+    var url = new URL(window.location.href);
+    url.search = new_url_params.join('&') + '&' + new URLSearchParams(other_new_url_params).toString();
+    history.replaceState(null, null, url);
+    console.log(url.searchParams)
 
-    if (sync) {
-      window.addEventListener("message", event => {
-        iframes.forEach(iframe => {
-          if (iframe.contentWindow !== event.source) {
-            iframe.contentWindow.postMessage(event.data, '*');
-          }
-        })
-      })
-    }
+    window.addEventListener("message", event => {
+        if (event.data.type === 'url') {
+          // This is the only way to get the location of the page in the iframe
+          // We can't access iframe.contentWindow.location.href directly due to CORS
+          // This is also the reason why the breadcrumbs and URL are not updated
+          // when navigating the directory structure of the iframe
+          let index = iframes.findIndex(iframe => iframe.contentWindow === event.source);
+          new_url_params[index] = event.data.url.replace('file://', '');
+          breadcrumbs[index].innerHTML = '';
+          createBreadcrumb(event.data.url, breadcrumbs[index], iframes[index]);
+          var url = new URL(window.location.href);
+          url.search = new_url_params.join('&') + '&' + new URLSearchParams(other_new_url_params).toString();
+          history.replaceState(null, null, url);
+        } else if (sync) {
+          iframes.forEach(iframe => {
+            if (iframe.contentWindow !== event.source) {
+              iframe.contentWindow.postMessage(event.data, '*');
+            }
+          })
+        }
+    })
 </script>
 </html>

--- a/meeteval/viz/visualize.css
+++ b/meeteval/viz/visualize.css
@@ -2,6 +2,7 @@
   width: 1em;
   height: 1.125em;
   /*vertical-align: -0.125em;*/
+    vertical-align: text-bottom;
 }
 
 .meeteval-viz {
@@ -85,7 +86,8 @@ code {
     display: flex;
     align-items: center;
     width: 100%;
-    overflow: hidden
+    overflow: hidden;
+    min-height: 2.5ex;
 }
 
 .selected-utterance-expand {
@@ -120,7 +122,7 @@ code {
 }
 
 audio.info-value {
-    height: 1.5em;
+    height: 2.2ex;
 }
 
 .legend-element {
@@ -253,7 +255,7 @@ visible area.
     opacity: 0;
     transition: opacity 0.3s;
     transition-delay: 2s;
-    max-width: 100vw;
+    max-width: 50vw;    /* Limit width to 50% of the viewport so that the tooltip can never cover the full screen area*/
     overflow: auto;
     box-sizing: border-box;
 

--- a/meeteval/viz/visualize.js
+++ b/meeteval/viz/visualize.js
@@ -1100,6 +1100,7 @@ class CanvasPlot {
         menuElement.append("input").classed("menu-control", true).attr("type", "range").attr("min", "1").attr("max", "90").classed("slider", true).attr("step", 1).on("input", function () {
             settings.match_width = parseInt(this.value) / 100;
             state.dirty[state.dirty.length - 1] = true;
+            details_plot.precompute_utterance_positions();
             update();
         }).node().value = settings.match_width * 100;
         menuElement = m.append("div").classed("menu-element", true)

--- a/meeteval/viz/visualize.js
+++ b/meeteval/viz/visualize.js
@@ -2096,7 +2096,7 @@ class CanvasPlot {
                     const x_ = x + d.width / 2;
                     context.font = `italic ${settings.font_size * this.plot.dpr}px Arial`;
                     context.fillStyle = "gray";
-                    context.fillText('(empty segment)', x_, (this.plot.y(d.start_time) + this.plot.y(d.end_time)) / 2);
+                    context.fillText('(empty)', x_, (this.plot.y(d.start_time) + this.plot.y(d.end_time)) / 2);
                 }
             });
 

--- a/meeteval/viz/visualize.js
+++ b/meeteval/viz/visualize.js
@@ -271,6 +271,13 @@ function alignment_visualization(
         encodeURL: true,
     }
 ) {
+
+    window.parent.postMessage({
+        type: 'url',
+        url: window.location.href,
+        }, '*'
+    )
+
     if (settings.font_size === undefined) {
         // The default from the function signature doesn't work.
         settings.font_size = 12;

--- a/meeteval/viz/visualize.js
+++ b/meeteval/viz/visualize.js
@@ -2318,7 +2318,7 @@ class CanvasPlot {
                         warning_field.style("display", "block")
                         audio.remove();
                         fallback_text_box.text(value + ' ');
-                        fallback_text_box.append('div').html(icons['warning']);
+                        fallback_text_box.append('div').style("display", "inline-block").html(icons['warning']);
                     }
                 };
                 audio.on('error', on_error_fn)

--- a/meeteval/viz/visualize.js
+++ b/meeteval/viz/visualize.js
@@ -512,14 +512,14 @@ function alignment_visualization(
         let currentViewAreaSize = end - start;
 
         // Nothing to do if the point is already in the viewport and not zoomed out too much
-        if (!moveIfInViewport && point > start && point < end && (currentViewAreaSize < constants.zoomThreshold)) return;
+        if (!moveIfInViewport && point > start && point < end && (currentViewAreaSize < constants.focusZoomThreshold)) return;
 
         // Limit the size of the viewport to maxViewAreaSize if the threshold is exceeded
-        if (currentViewAreaSize > zoomThreshold) {
-            currentViewAreaSize = constants.maxViewAreaSize;
+        if (currentViewAreaSize > constants.focusZoomThreshold) {
+            currentViewAreaSize = constants.focusMaxViewAreasize;
         }
 
-        const viewArea = [viewArea - currentViewAreaSize / 2, viewArea + currentViewAreaSize / 2];
+        const viewArea = [point - currentViewAreaSize / 2, point + currentViewAreaSize / 2];
 
         animateToViewArea(state.viewAreas.length - 1, viewArea, moveIfInViewport);
     }
@@ -541,8 +541,8 @@ function alignment_visualization(
         const areaCenter = (area[0] + area[1]) / 2;
 
         // Zoom in if the current view area is too large
-        if (areaSize < constants.zoomThreshold && viewAreaSize > constants.zoomThreshold) {
-            viewAreaSize = Math.max(constants.maxViewAreaSize, areaSize);
+        if (areaSize < constants.focusZoomThreshold && viewAreaSize > constants.focusZoomThreshold) {
+            viewAreaSize = Math.max(constants.focusMaxViewAreasize, areaSize);
         }
 
         // Zoom out if the area is larger than the current view area

--- a/meeteval/viz/visualize.py
+++ b/meeteval/viz/visualize.py
@@ -464,6 +464,7 @@ class AlignmentVisualization:
             js_debug=False,  # If True, don't embed js (and css) code and use absolute paths
             sync_id=None,
             precomputed_error_rate=None,   # A precomputed assignment. Saves computation
+            show_playhead=True,
     ):
         if isinstance(reference, (str, Path)):
             reference = meeteval.io.load(reference)
@@ -492,6 +493,7 @@ class AlignmentVisualization:
         self.recording_file = recording_file
         self.sync_id = sync_id
         self.precomputed_error_rate = precomputed_error_rate
+        self.show_playhead = show_playhead
 
     def _get_colormap(self):
         if isinstance(self.colormap, str):
@@ -687,6 +689,7 @@ class AlignmentVisualization:
                             syncID: {dumps_json(self.sync_id, default='null')},
                             audio_server: 'http://localhost:7777',
                             encodeURL: {'true' if encode_url else 'false'},
+                            show_playhead: {'true' if self.show_playhead else 'false'},
                         }}
                     );
                     else setTimeout(exec, 100);

--- a/meeteval/viz/visualize.py
+++ b/meeteval/viz/visualize.py
@@ -454,7 +454,7 @@ class AlignmentVisualization:
             colormap='default',
             barplot_style='absolute',
             barplot_scale_exclude_total=False,
-            num_minimaps=2,
+            num_minimaps='auto',
             show_details=True,
             show_legend=True,
             highlight_regex=None,
@@ -639,6 +639,21 @@ class AlignmentVisualization:
         d3 = f'<script>{load_cdn("d3.js", cdn["d3"])}</script>'
         # font_awesome = f'<style>{load_cdn("d3font_awesome.css", cdn["font_awesome"])}</style>'
 
+        # Determine the number of minimaps based on the number of utterances. If it's a large number, 
+        # use two minimaps, else use one
+        # Typical number of utterances (`max([len(v) for v in meeteval.io.load('ref.seglst.json').groupby('session_id').values()]) * 2`):
+        #   - libricss: 250
+        #   - notsofar: 652
+        #   - dipco: 2568
+        #   - chime6: 6738
+        if self.num_minimaps == 'auto':
+            if len(self.data['utterances']) > 1000:
+                num_minimaps = 2
+            else:
+                num_minimaps = 1
+        else:
+            num_minimaps = self.num_minimaps
+
         font_awesome = ''
         html = f'''
             {d3}
@@ -660,7 +675,7 @@ class AlignmentVisualization:
                                 scaleExcludeCorrect: {'true' if self.barplot_scale_exclude_total else 'false'}
                             }},
                             minimaps: {{
-                                number: {self.num_minimaps}
+                                number: {num_minimaps}
                             }},
                             show_details: {'true' if self.show_details else 'false'},
                             show_legend: {'true' if self.show_legend else 'false'},

--- a/meeteval/viz/visualize.py
+++ b/meeteval/viz/visualize.py
@@ -1,12 +1,9 @@
-import logging
 import os
 from meeteval.wer.wer.utils import check_single_filename
 import urllib.request
-
 import meeteval
 from meeteval.wer import ErrorRate
 
-logging.basicConfig(level=logging.ERROR)
 import dataclasses
 import functools
 import uuid

--- a/meeteval/viz/visualize.py
+++ b/meeteval/viz/visualize.py
@@ -348,6 +348,11 @@ def get_visualization_data(ref: SegLST, hyp: SegLST, assignment='tcp', alignment
         'duration': w['end_time'] - w['start_time'],
     })
 
+     # Add info about the number of errors to each uttearnce
+    for word in words:
+        utterance = u[word['utterance_index']]
+        utterance['errors'] = utterance.get('errors', 0) + (0 if 'matches' in word and word['matches'] and word['matches'][0][1] == 'correct' else 1)
+
     compress = True
     if compress:
         data['words'] = {k: words.T.get(k) for k in words.T.keys(all=True)}

--- a/meeteval/viz/visualize.py
+++ b/meeteval/viz/visualize.py
@@ -186,10 +186,30 @@ def get_error_rate(ref, hyp, assignment):
             reference_pseudo_word_level_timing='character_based',
             hypothesis_pseudo_word_level_timing='character_based_points',
         )
-        ref, hyp = wer.apply_assignment(ref, hyp)
+    elif assignment == 'greedy_tcorc':
+        wer = meeteval.wer.wer.greedy_time_constrained_orc_wer(
+            ref, hyp,
+            collar=5,
+            reference_sort='segment',
+            hypothesis_sort='segment',
+            reference_pseudo_word_level_timing='character_based',
+            hypothesis_pseudo_word_level_timing='character_based_points',
+        )
+    elif assignment == 'greedy_ditcp':
+        wer = meeteval.wer.wer.greedy_di_tcp_word_error_rate(
+            ref, hyp,
+            collar=5,
+            reference_sort='segment',
+            hypothesis_sort='segment',
+            reference_pseudo_word_level_timing='character_based',
+            hypothesis_pseudo_word_level_timing='character_based_points',
+        )
     elif assignment == 'orc':
         wer = meeteval.wer.wer.orc.orc_word_error_rate(ref, hyp)
-        ref, hyp = wer.apply_assignment(ref, hyp)
+    elif assignment == 'greedy_orc':
+        wer = meeteval.wer.wer.greedy_orc_word_error_rate(ref, hyp)
+    elif assignment == 'greedy_dicp':
+        wer = meeteval.wer.wer.greedy_di_cp_word_error_rate(ref, hyp)
     else:
         raise ValueError(assignment)
     

--- a/meeteval/wer/__main__.py
+++ b/meeteval/wer/__main__.py
@@ -460,7 +460,19 @@ class SmartFormatter(argparse.ArgumentDefaultsHelpFormatter):
             for i, t in enumerate(text.split('\n'))
             for tt in textwrap.wrap(t, width, subsequent_indent='  ' if i > 0 else '')
         ]
-
+    
+    def _fill_text(self, text: str, width: int, indent: str) -> str:
+        """
+        Extends `_fill_text` to work with multiple paragraphs, separated by \n\n.
+        This function is used to format the (long) command descriptions at the top of 
+        the help text.
+        """
+        import textwrap
+        text = textwrap.dedent(text)
+        return '\n\n'.join(
+            textwrap.fill(p, width, initial_indent=indent, subsequent_indent=indent)
+            for p in text.split('\n\n')
+        )
 
 class CLI:
     def __init__(self):
@@ -660,10 +672,10 @@ class CLI:
             command_name = fn.__name__
         command_parser = self.commands.add_parser(
             command_name,
-            description=fn.__doc__,
+            description=fn.__doc__, # Use full docstring as description at the top of the help text (e.g., meeteval-wer cpwer --help)
+            help=fn.__doc__.split('\n\n')[0],   # Use first paragraph as short help text in the command list (e.g., meeteval-wer --help)
+            formatter_class=SmartFormatter, # Custom formatter for help and description texts
             add_help=False,
-            formatter_class=SmartFormatter,
-            help=fn.__doc__,
         )
         command_parser.add_argument(
             '--help', help='show this help message and exit',

--- a/meeteval/wer/__main__.py
+++ b/meeteval/wer/__main__.py
@@ -672,8 +672,10 @@ class CLI:
             command_name = fn.__name__
         command_parser = self.commands.add_parser(
             command_name,
-            description=fn.__doc__, # Use full docstring as description at the top of the help text (e.g., meeteval-wer cpwer --help)
-            help=fn.__doc__.split('\n\n')[0],   # Use first paragraph as short help text in the command list (e.g., meeteval-wer --help)
+            # Use full docstring as description at the top of the help text (e.g., meeteval-wer cpwer --help)
+            description=fn.__doc__,
+            # Use first paragraph as short help text in the command list (e.g., meeteval-wer --help)
+            help=fn.__doc__.split('\n\n')[0] if fn.__doc__ is not None else None,
             formatter_class=SmartFormatter, # Custom formatter for help and description texts
             add_help=False,
         )

--- a/setup.py
+++ b/setup.py
@@ -136,6 +136,7 @@ setup(
         'console_scripts': [
             'meeteval-wer=meeteval.wer.__main__:cli',
             'meeteval-der=meeteval.der.__main__:cli',
+            'meeteval-viz=meeteval.viz.__main__:cli',
         ]
     },
     include_dirs=[numpy.get_include()],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -194,3 +194,9 @@ def test_viz_html():
     run(f'python -m meeteval.viz html -h hyp.stm -r ref.stm --alignment=tcp')
     run(f'python -m meeteval.viz html -h hyp.stm -r ref.stm --alignment=cp')
     run(f'python -m meeteval.viz html -h hyp.stm -r ref.stm --out=viz')
+    run(f'python -m meeteval.viz html -h hyp.stm -r ref.stm --alignment cp tcorc')
+
+    # Test loading a precomputed assignment
+    run(f'python -m meeteval.wer cpwer -h hyp.stm -r ref.stm --per-reco-out hyp_cpwer_per_reco.json')
+    run(f'python -m meeteval.wer tcorcwer -h hyp.stm -r ref.stm --per-reco-out hyp_tcorcwer_per_reco.json --collar 5')
+    run(f'meeteval-viz html -h hyp.stm -r ref.stm --alignment cp tcorc --per-reco-file hyp_cpwer_per_reco.json hyp_tcorcwer_per_reco.json')

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -1,0 +1,79 @@
+import meeteval.viz
+from pathlib import Path
+import pytest
+
+example_files = (Path(__file__).parent.parent / 'example_files').absolute()
+
+
+@pytest.mark.parametrize(
+    'alignment',
+    [
+        'cp', 'tcp', 'orc', 'tcorc', 'greedy_tcorc',
+        'greedy_orc', 'greedy_dicp', 'greedy_ditcp'
+    ]
+)
+def test_viz_burn(alignment):
+    """
+    Tests if the code that generated the visualization produces an html file.
+    Does not test if the visualization is correct.
+    """
+    ref = meeteval.io.asseglst(meeteval.io.load(example_files / 'hyp.stm')).groupby('session_id')
+    hyp = meeteval.io.asseglst(meeteval.io.load(example_files / 'ref.stm')).groupby('session_id')
+
+    for k in ref.keys():
+        meeteval.viz.AlignmentVisualization(
+            ref[k],
+            hyp[k],
+            alignment=alignment,
+        ).dump(example_files / f'viz/test-{k}-{alignment}.html')
+        assert (example_files / f'viz/test-{k}-{alignment}.html').exists()
+
+
+@pytest.mark.parametrize(
+    'alignment',
+    [
+        'cp', 'tcp', 'orc', 'tcorc', 'greedy_tcorc',
+        'greedy_orc', 'greedy_dicp', 'greedy_ditcp'
+    ]
+)
+def test_viz_precompute_wer(alignment):
+    """
+    Tests if the code that generated the visualization produces an html file
+    when the WER (and assignment) are precomputed.
+    Does not test if the visualization is correct.
+    """
+    ref = meeteval.io.asseglst(meeteval.io.load(example_files / 'hyp.stm')).groupby('session_id')
+    hyp = meeteval.io.asseglst(meeteval.io.load(example_files / 'ref.stm')).groupby('session_id')
+
+    for k in ref.keys():
+        # Precompute WER
+        wer = getattr(meeteval.wer.api, alignment + 'wer')(
+            ref[k], hyp[k],
+            **({'collar': 5} if 'tc' in alignment else {})
+        )[k]
+
+        # With precomputed WER
+        meeteval.viz.AlignmentVisualization(
+            ref[k],
+            hyp[k],
+            alignment=alignment,
+            precomputed_error_rate=wer,
+        ).dump(example_files / f'viz/test-{k}-{alignment}-precomputed.html')
+        assert (example_files / f'viz/test-{k}-{alignment}-precomputed.html').exists()
+
+        # Without precomputed WER
+        meeteval.viz.AlignmentVisualization(
+            ref[k],
+            hyp[k],
+            alignment=alignment,
+        ).dump(example_files / f'viz/test-{k}-{alignment}.html')
+        assert (example_files / f'viz/test-{k}-{alignment}.html').exists()
+
+        # Test that file contents are identical. Only the (randomly generated)
+        # visualization ID should differ.
+        import re
+        precomputed_text = (example_files / f'viz/test-{k}-{alignment}-precomputed.html').read_text()
+        precomputed_text = re.sub(r'viz-[0-9a-f\-]*', '#viz-XXXX', precomputed_text)
+        text = (example_files / f'viz/test-{k}-{alignment}.html').read_text()
+        text = re.sub(r'viz-[0-9a-f\-]*', '#viz-XXXX', text)
+        assert text == precomputed_text


### PR DESCRIPTION
- Add all supported assignment options to the visualization (cp, tcp, orc, tcorc, greedy_dicp, ...)
- Add entrypoint `meeteval-viz`
- Add option to load a precomputed assignment from a `*_per_reco.json` file (or an `ErrorRate` object in the Python interface)
- Automatically increase the number of minimaps for large examples
- Show current playhead position in details plot on playback