### PR TITLE
Add dscore like DER

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ MeetEval supports the following metrics for meeting transcription evaluation:
   `meeteval-wer greedy_tcorcwer -r ref.stm -h hyp.stm --collar 5`
 - **Diarization-Invariant cpWER (DI-cpWER)**<br>
   `meeteval-wer greedy_dicpwer -r ref.stm -h hyp.stm`
+- **Diarization Error Rate (DER)** by wrapping [mdeval](https://github.com/nryant/dscore/raw/master/scorelib/md-eval-22.pl) like dscore<br>
+  `meeteval-der dscore -r ref.stm -h hyp.stm --collar .25`
 - **Diarization Error Rate (DER)** by wrapping [mdeval](https://github.com/nryant/dscore/raw/master/scorelib/md-eval-22.pl)<br>
   `meeteval-der md_eval_22 -r ref.stm -h hyp.stm --collar .25`
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ MeetEval supports the following metrics for meeting transcription evaluation:
   `meeteval-wer greedy_tcorcwer -r ref.stm -h hyp.stm --collar 5`
 - **Diarization-Invariant cpWER (DI-cpWER)**<br>
   `meeteval-wer greedy_dicpwer -r ref.stm -h hyp.stm`
-- **Diarization Error Rate (DER)** by wrapping [mdeval](https://github.com/nryant/dscore/raw/master/scorelib/md-eval-22.pl) like dscore<br>
+- **Diarization Error Rate (DER)** by wrapping [mdeval](https://github.com/nryant/dscore/raw/master/scorelib/md-eval-22.pl) like dscore (see https://github.com/fgnt/meeteval/issues/97#issuecomment-2508140402)<br>
   `meeteval-der dscore -r ref.stm -h hyp.stm --collar .25`
 - **Diarization Error Rate (DER)** by wrapping [mdeval](https://github.com/nryant/dscore/raw/master/scorelib/md-eval-22.pl)<br>
   `meeteval-der md_eval_22 -r ref.stm -h hyp.stm --collar .25`

--- a/meeteval/der/__main__.py
+++ b/meeteval/der/__main__.py
@@ -39,6 +39,7 @@ def dscore(
     """
     Computes the Diarization Error Rate (DER) using md-eval-22.pl,
     but create a uem if uem is None, as it is done in dscore [1].
+    Commonly used in challenge evaluations, e.g., DIHARD II, CHiME.
 
     [1] https://github.com/nryant/dscore
     """
@@ -85,8 +86,8 @@ def cli():
 
     cli = DerCLI()
 
-    cli.add_command(md_eval_22)
     cli.add_command(dscore)
+    cli.add_command(md_eval_22)
 
     cli.run()
 

--- a/meeteval/der/__main__.py
+++ b/meeteval/der/__main__.py
@@ -26,6 +26,34 @@ def md_eval_22(
     _save_results(results, hypothesis, per_reco_out, average_out, wer_name='DER')
 
 
+def dscore(
+        reference,
+        hypothesis,
+        average_out='{parent}/{stem}_dscore.json',
+        per_reco_out='{parent}/{stem}_dscore_per_reco.json',
+        collar=0,
+        regions='all',
+        regex=None,
+        uem=None,
+):
+    """
+    Computes the Diarization Error Rate (DER) using md-eval-22.pl,
+    but create a uem if uem is None, as it is done in dscore [1].
+
+    [1] https://github.com/nryant/dscore
+    """
+    from meeteval.der.api import dscore
+    results = dscore(
+        reference,
+        hypothesis,
+        collar=collar,
+        regex=regex,
+        regions=regions,
+        uem=uem,
+    )
+    _save_results(results, hypothesis, per_reco_out, average_out, wer_name='DER')
+
+
 def cli():
     from meeteval.wer.__main__ import CLI
 
@@ -58,6 +86,7 @@ def cli():
     cli = DerCLI()
 
     cli.add_command(md_eval_22)
+    cli.add_command(dscore)
 
     cli.run()
 

--- a/meeteval/der/api.py
+++ b/meeteval/der/api.py
@@ -4,6 +4,7 @@ from meeteval.wer.api import _load_texts
 
 __all__ = [
     'md_eval_22',
+    'dscore',
 ]
 
 
@@ -23,6 +24,27 @@ def md_eval_22(
             uem = UEM.load(uem)
 
     results = md_eval_22_multifile(
+        r, h, collar, regions=regions, uem=uem
+    )
+    return results
+
+
+def dscore(
+        reference,
+        hypothesis,
+        collar=0,
+        regions='all',
+        regex=None,
+        uem=None,
+):
+    r, h = _load_texts(reference, hypothesis, regex)
+    from meeteval.der.dscore import dscore_multifile
+    if uem is not None:
+        from meeteval.io.uem import UEM
+        if isinstance(uem, (str, Path, list, tuple)):
+            uem = UEM.load(uem)
+
+    results = dscore_multifile(
         r, h, collar, regions=regions, uem=uem
     )
     return results

--- a/meeteval/der/dscore.py
+++ b/meeteval/der/dscore.py
@@ -183,12 +183,25 @@ def dscore_multifile(
     return result
 
 
-def dscore(reference, hypothesis, collar=0, regions='all', uem=None):
+def dscore(reference, hypothesis, collar=0, regions='all', uem=None, sanity_check=False):
     """
     Computes the Diarization Error Rate (DER) using md-eval-22.pl
     but create a uem if uem is None, as it is done in dscore [1].
 
-    Additionally, compare the error rate with dscore [1].
+    Additionally, compare the error rate with dscore [1], if sanity_check is True.
+
+    Args:
+        reference:
+        hypothesis:
+        collar:
+        regions: 'all' or 'nooverlap'
+        uem: If None, generate a uem from the reference and hypothesis.
+             This is the default behavior of dscore, while md-eval-22,
+             uses only the reference.
+        sanity_check: Compare the result with dscore to ensure
+                      the correctness of the implementation.
+                      Requires the numpy < 1.24 (e.g. np.int),
+                      because dscore fails with recent numpy versions.
 
     [1] https://github.com/nryant/dscore
 
@@ -238,7 +251,9 @@ def dscore(reference, hypothesis, collar=0, regions='all', uem=None):
     uem_md_eval, uem_dscore = _maybe_gen_uem(uem, reference, hypothesis)
 
     result = md_eval_22(reference, hypothesis, collar=collar, regions=regions, uem=uem_md_eval)
-    dscore_der = _dscore_multifile(reference, hypothesis, collar=collar, regions=regions, uem=uem_dscore)
 
-    assert list(dscore_der.values()) == [result.error_rate], (dscore_der, result.error_rate)
+    if sanity_check:
+        dscore_der = _dscore_multifile(reference, hypothesis, collar=collar, regions=regions, uem=uem_dscore)
+        assert list(dscore_der.values()) == [result.error_rate], (dscore_der, result.error_rate)
+
     return result

--- a/meeteval/der/dscore.py
+++ b/meeteval/der/dscore.py
@@ -166,7 +166,7 @@ def dscore_multifile(
     ... SPEAKER rec 1 10.00 10.00 <NA> <NA> spk00 <NA>
     ... ''')
     >>> import pprint
-    >>> pprint.pprint(dscore_multifile(reference, hypothesis))
+    >>> pprint.pprint(dscore_multifile(reference, hypothesis))  # doctest: +NORMALIZE_WHITESPACE
     {'rec': DiaErrorRate(error_rate=Decimal('0.3333'),
                          scored_speaker_time=Decimal('15.000000'),
                          missed_speaker_time=Decimal('0.000000'),
@@ -174,7 +174,7 @@ def dscore_multifile(
                          speaker_error_time=Decimal('0.000000'))}
 
     >>> from meeteval.der.md_eval import md_eval_22_multifile
-    >>> pprint.pprint(md_eval_22_multifile(reference, hypothesis))
+    >>> pprint.pprint(md_eval_22_multifile(reference, hypothesis))  # doctest: +NORMALIZE_WHITESPACE
     {'rec': DiaErrorRate(error_rate=Decimal('0.00'),
                          scored_speaker_time=Decimal('15.000000'),
                          missed_speaker_time=Decimal('0.000000'),
@@ -235,13 +235,13 @@ def dscore(reference, hypothesis, collar=0, regions='all', uem=None, sanity_chec
     ... ''')
     >>> import pprint
 
-    >>> pprint.pprint(dscore(reference, hypothesis))
+    >>> pprint.pprint(dscore(reference, hypothesis))  # doctest: +NORMALIZE_WHITESPACE
     DiaErrorRate(error_rate=Decimal('0.3333'),
                  scored_speaker_time=Decimal('15.000000'),
                  missed_speaker_time=Decimal('0.000000'),
                  falarm_speaker_time=Decimal('5.000000'),
                  speaker_error_time=Decimal('0.000000'))
-    >>> pprint.pprint(dscore(reference, hypothesis, uem=uem))
+    >>> pprint.pprint(dscore(reference, hypothesis, uem=uem))  # doctest: +NORMALIZE_WHITESPACE
     DiaErrorRate(error_rate=Decimal('0.50'),
                  scored_speaker_time=Decimal('10.000000'),
                  missed_speaker_time=Decimal('0.000000'),
@@ -250,7 +250,7 @@ def dscore(reference, hypothesis, collar=0, regions='all', uem=None, sanity_chec
 
     # md_eval_22 ignores hyps before the first ref and after the last ref
     >>> from meeteval.der.md_eval import md_eval_22
-    >>> pprint.pprint(md_eval_22(reference, hypothesis))  # doctest: +ELLIPSIS
+    >>> pprint.pprint(md_eval_22(reference, hypothesis))  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
     DiaErrorRate(error_rate=Decimal('0.00'),
                  scored_speaker_time=Decimal('15.000000'),
                  missed_speaker_time=Decimal('0.000000'),

--- a/meeteval/der/dscore.py
+++ b/meeteval/der/dscore.py
@@ -15,8 +15,9 @@ def _dscore_multifile(
     the details. Hence, call dscore only to compare the error rate
     with md_eval_22_multifile.
 
+    >>> import packaging.version
     >>> import numpy as np
-    >>> if (int(np.__version__.split('.')[0]), int(np.__version__.split('.')[0])) >= (1, 24):
+    >>> if packaging.version.parse(np.__version__) >= packaging.version.parse('1.24'):
     ...     import pytest
     ...     pytest.skip(f'dscore fails with numpy >= 1.24. Current version: {np.__version__}')
 

--- a/meeteval/der/dscore.py
+++ b/meeteval/der/dscore.py
@@ -1,0 +1,244 @@
+import logging
+import sys
+import subprocess
+import tempfile
+import decimal
+from pathlib import Path
+
+
+def _dscore_multifile(
+        reference, hypothesis, collar=0, regions='all',
+        uem=None
+):
+    """
+    dscore produces a table with the final scores, but we need
+    the details. Hence, call dscore only to compare the error rate
+    with md_eval_22_multifile.
+
+    >>> from meeteval.io.rttm import RTTM
+    >>> from meeteval.io.uem import UEM
+    >>> reference = RTTM.parse('''
+    ... SPEAKER S1 1 0.0 0.5 <NA> <NA> spk1 <NA>
+    ... SPEAKER S1 1 0.5 0.5 <NA> <NA> spk2 <NA>
+    ... SPEAKER S1 1 1.0 0.5 <NA> <NA> spk1 <NA>
+    ... ''')
+    >>> hypothesis = RTTM.parse('''
+    ... SPEAKER S1 1 0.0 0.5 <NA> <NA> spk1 <NA>
+    ... SPEAKER S1 1 0.5 0.5 <NA> <NA> spk2 <NA>
+    ... SPEAKER S1 1 1.0 0.5 <NA> <NA> spk2 <NA>
+    ... ''')
+    >>> uem = UEM.parse('''
+    ... S1 1 0.0 1.5
+    ... ''')
+    >>> import pprint
+    >>> pprint.pprint(dscore_multifile(reference, hypothesis, uem=uem))
+    {'S1': DiaErrorRate(error_rate=Decimal('0.3333'),
+                        scored_speaker_time=Decimal('1.500000'),
+                        missed_speaker_time=Decimal('0.000000'),
+                        falarm_speaker_time=Decimal('0.000000'),
+                        speaker_error_time=Decimal('0.500000'))}
+    """
+    from meeteval.der.md_eval import _FilenameEscaper
+    escaper = _FilenameEscaper()
+
+    from meeteval.io.rttm import RTTM
+    reference = RTTM.new(reference)
+    hypothesis = RTTM.new(hypothesis)
+
+    reference = escaper.escape_rttm(reference)
+    hypothesis = escaper.escape_rttm(hypothesis)
+
+    score_py = Path(__file__).parent / 'dscore_repo' / 'score.py'
+    if not score_py.exists():
+        subprocess.run(['git', 'clone', 'https://github.com/nryant/dscore.git', score_py.parent])
+
+    filtered = 0
+    for line in reference:
+        if line.duration == 0:
+            filtered += 1
+    if filtered:
+        logging.info(f'Filtered {filtered} lines with zero duration in reference (dscore doesn\'t support zero duration)')
+        reference = RTTM([line for line in reference if line.duration != 0])
+
+    filtered = 0
+    for line in hypothesis:
+        if line.duration == 0:
+            filtered += 1
+    if filtered:
+        logging.info(f'Filtered {filtered} lines with zero duration in hypothesis (dscore doesn\'t support zero duration)')
+        hypothesis = RTTM([line for line in hypothesis if line.duration != 0])
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+
+        r_file = tmpdir / f'ref.rttm'
+        h_file = tmpdir / f'hyp.rttm'
+        reference.dump(r_file)
+        hypothesis.dump(h_file)
+
+        cmd = [
+            sys.executable, str(score_py),
+            '--collar', str(collar),
+            # '--ignore_overlaps', regions,
+            '-r', f'{r_file}',
+            '-s', f'{h_file}',
+            '--table_fmt', 'tsv'
+        ]
+        if uem:
+            uem_file = tmpdir / 'uem.rttm'
+            uem = escaper.escape_uem(uem)
+            uem.dump(uem_file)
+            cmd.extend(['-u', f'{uem_file}'])
+
+        if regions == 'all':
+            pass
+        elif regions == 'nooverlap':
+            cmd.append('--ignore_overlaps')
+
+        p = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            # stderr=subprocess.PIPE,
+            check=True, universal_newlines=True,
+            cwd=score_py.parent
+        )
+
+        result = {}
+        for line in p.stdout.strip().split('\n')[1:-1]:
+            line_parts = line.split('\t')
+            result[escaper.restore(line_parts[0].strip())] = decimal.Decimal(line_parts[1].strip()) / 100
+
+        assert result, p.stdout
+        return result
+
+
+def _maybe_gen_uem(uem, reference, hypothesis):
+    # Mirror the behavior of dscore
+    if uem is None:
+        from meeteval.io.uem import UEM, UEMLine
+        uem_md_eval = UEM([
+            UEMLine(
+                filename=k, channel='1',
+                begin_time=min(v.T['start_time']), end_time=max(v.T['end_time'])
+            )
+            for k, v in (reference + hypothesis).to_seglst().groupby('session_id').items()
+        ])
+
+        return uem_md_eval, None
+    else:
+        return uem, uem
+
+
+def dscore_multifile(
+        reference, hypothesis, collar=0, regions='all',
+        uem=None
+):
+    """
+    Computes the Diarization Error Rate (DER) using md-eval-22.pl
+    but create a uem if uem is None, as it is done in dscore [1].
+
+    Additionally, compare the error rate with dscore [1].
+
+    [1] https://github.com/nryant/dscore
+
+    >>> from meeteval.io.rttm import RTTM
+    >>> from meeteval.io.uem import UEM
+    >>> reference = RTTM.parse('''
+    ... SPEAKER rec 1 5.00 5.00 <NA> <NA> spk01 <NA>
+    ... SPEAKER rec 1 10.00 10.00 <NA> <NA> spk00 <NA>
+    ... ''')
+    >>> hypothesis = RTTM.parse('''
+    ... SPEAKER rec 1 0.00 10.00 <NA> <NA> spk01 <NA>
+    ... SPEAKER rec 1 10.00 10.00 <NA> <NA> spk00 <NA>
+    ... ''')
+    >>> import pprint
+    >>> pprint.pprint(dscore_multifile(reference, hypothesis))
+    {'rec': DiaErrorRate(error_rate=Decimal('0.3333'),
+                         scored_speaker_time=Decimal('15.000000'),
+                         missed_speaker_time=Decimal('0.000000'),
+                         falarm_speaker_time=Decimal('5.000000'),
+                         speaker_error_time=Decimal('0.000000'))}
+
+    >>> from meeteval.der.md_eval import md_eval_22_multifile
+    >>> pprint.pprint(md_eval_22_multifile(reference, hypothesis))
+    {'rec': DiaErrorRate(error_rate=Decimal('0.00'),
+                         scored_speaker_time=Decimal('15.000000'),
+                         missed_speaker_time=Decimal('0.000000'),
+                         falarm_speaker_time=Decimal('0.000000'),
+                         speaker_error_time=Decimal('0.000000'))}
+
+    """
+    from meeteval.der.md_eval import md_eval_22_multifile
+
+    uem_md_eval, uem_dscore = _maybe_gen_uem(uem, reference, hypothesis)
+
+    result = md_eval_22_multifile(
+        reference, hypothesis, collar=collar, regions=regions, uem=uem_md_eval
+    )
+    dscore_der = _dscore_multifile(reference, hypothesis, collar=collar, regions=regions, uem=uem_dscore)
+    for key in result:
+        assert key in dscore_der, (key, result, dscore_der)
+        assert abs(dscore_der[key] - result[key].error_rate) <= decimal.Decimal('0.0001'), (key, dscore_der[key], result[key])
+
+    return result
+
+
+def dscore(reference, hypothesis, collar=0, regions='all', uem=None):
+    """
+    Computes the Diarization Error Rate (DER) using md-eval-22.pl
+    but create a uem if uem is None, as it is done in dscore [1].
+
+    Additionally, compare the error rate with dscore [1].
+
+    [1] https://github.com/nryant/dscore
+
+    >>> from meeteval.io.rttm import RTTM
+    >>> from meeteval.io.uem import UEM
+    >>> reference = RTTM.parse('''
+    ... SPEAKER rec.a 1 5.00 5.00 <NA> <NA> spk01 <NA>
+    ... SPEAKER rec.a 1 10.00 10.00 <NA> <NA> spk00 <NA>
+    ... ''')
+    >>> hypothesis = RTTM.parse('''
+    ... SPEAKER rec.a 1 0.00 10.00 <NA> <NA> spk01 <NA>
+    ... SPEAKER rec.a 1 10.00 10.00 <NA> <NA> spk00 <NA>
+    ... ''')
+    >>> uem = UEM.parse('''
+    ... rec.a 1 0.00 15.00
+    ... ''')
+    >>> import pprint
+
+    >>> pprint.pprint(dscore(reference, hypothesis))
+    DiaErrorRate(error_rate=Decimal('0.3333'),
+                 scored_speaker_time=Decimal('15.000000'),
+                 missed_speaker_time=Decimal('0.000000'),
+                 falarm_speaker_time=Decimal('5.000000'),
+                 speaker_error_time=Decimal('0.000000'))
+    >>> pprint.pprint(dscore(reference, hypothesis, uem=uem))
+    DiaErrorRate(error_rate=Decimal('0.50'),
+                 scored_speaker_time=Decimal('10.000000'),
+                 missed_speaker_time=Decimal('0.000000'),
+                 falarm_speaker_time=Decimal('5.000000'),
+                 speaker_error_time=Decimal('0.000000'))
+
+    # md_eval_22 ignores hyps before the first ref and after the last ref
+    >>> from meeteval.der.md_eval import md_eval_22
+    >>> pprint.pprint(md_eval_22(reference, hypothesis))  # doctest: +ELLIPSIS
+    DiaErrorRate(error_rate=Decimal('0.00'),
+                 scored_speaker_time=Decimal('15.000000'),
+                 missed_speaker_time=Decimal('0.000000'),
+                 falarm_speaker_time=Decimal('0.000000'),
+                 speaker_error_time=Decimal('0.000000'))
+    """
+    from meeteval.der.md_eval import md_eval_22
+    from meeteval.io.rttm import RTTM
+
+    reference = RTTM.new(reference, filename='dummy')
+    hypothesis = RTTM.new(hypothesis, filename='dummy')
+
+    uem_md_eval, uem_dscore = _maybe_gen_uem(uem, reference, hypothesis)
+
+    result = md_eval_22(reference, hypothesis, collar=collar, regions=regions, uem=uem_md_eval)
+    dscore_der = _dscore_multifile(reference, hypothesis, collar=collar, regions=regions, uem=uem_dscore)
+
+    assert list(dscore_der.values()) == [result.error_rate], (dscore_der, result.error_rate)
+    return result

--- a/meeteval/der/md_eval.py
+++ b/meeteval/der/md_eval.py
@@ -92,7 +92,7 @@ class _FilenameEscaper:
     ... rec.a 1 0.00 15.00
     ... ''')
 
-    >>> pprint.pprint(md_eval_22_multifile(reference, hypothesis, uem=uem))
+    >>> pprint.pprint(md_eval_22_multifile(reference, hypothesis, uem=uem))  # doctest: +NORMALIZE_WHITESPACE
     {'rec.a': DiaErrorRate(error_rate=Decimal('0.50'),
                            scored_speaker_time=Decimal('10.000000'),
                            missed_speaker_time=Decimal('0.000000'),
@@ -100,7 +100,7 @@ class _FilenameEscaper:
                            speaker_error_time=Decimal('0.000000'))}
 
     >>> _FilenameEscaper._DISABLED = True
-    >>> pprint.pprint(md_eval_22_multifile(reference, hypothesis, uem=uem))
+    >>> pprint.pprint(md_eval_22_multifile(reference, hypothesis, uem=uem))  # doctest: +NORMALIZE_WHITESPACE
     {'rec.a': DiaErrorRate(error_rate=Decimal('0.00'),
                            scored_speaker_time=Decimal('15.000000'),
                            missed_speaker_time=Decimal('0.000000'),

--- a/meeteval/der/md_eval.py
+++ b/meeteval/der/md_eval.py
@@ -227,7 +227,11 @@ def md_eval_22_multifile(
             urllib.request.urlretrieve(url, md_eval_22)
             logging.info(f'Wrote {md_eval_22}')
 
+    warned = False
+
     def get_details(r, h, key, tmpdir, uem):
+        nonlocal warned
+
         r_file = tmpdir / f'{key}.ref.rttm'
         h_file = tmpdir / f'{key}.hyp.rttm'
         r.dump(r_file)
@@ -248,7 +252,9 @@ def md_eval_22_multifile(
             uem = escaper.escape_uem(uem)
             uem.dump(uem_file)
             cmd.extend(['-u', f'{uem_file}'])
-
+        elif not warned:
+            warned = True
+            logging.warning(f'No UEM file provided. See https://github.com/fgnt/meeteval/issues/97#issuecomment-2508140402 for details.')
         cp = subprocess.run(cmd, stdout=subprocess.PIPE,
                             check=True, universal_newlines=True)
 

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,8 @@ setup(
         'scipy',  # scipy.optimize.linear_sum_assignment
         "typing_extensions; python_version<'3.8'",  # Missing Literal in py37
         "cached_property; python_version<'3.8'",  # Missing functools.cached_property in py37
-        'Cython'
+        'Cython',
+        'packaging',  # commonly used to compare python versions, e.g., used by jupyter, matplotlib, pytest, ...
     ],
     extras_require=extras_require,
     package_data={'meeteval': ['**/*.pyx', '**/*.h', '**/*.js', '**/*.css', '**/*.html']},  # https://stackoverflow.com/a/60751886

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -156,6 +156,15 @@ def test_burn_md_eval_22():
     # ToDo: Table 2 of https://arxiv.org/pdf/2312.04324.pdf lists collars for
     #       datsets. Add them here.
 
+def test_burn_dscore():
+    run(f'python -m meeteval.der dscore -h hyp.stm -r ref.stm')
+    run(f'meeteval-der dscore -h hyp.stm -r ref.stm')
+    run(f'python -m meeteval.der dscore -h hyp.stm -r ref.stm --collar 0.25')
+    run(f'python -m meeteval.der dscore -h hyp.rttm -r ref.rttm')
+    run(f'python -m meeteval.der dscore -h hyp.rttm -r ref.rttm --regions all')
+    run(f'python -m meeteval.der dscore -h hyp.rttm -r ref.rttm --regions nooverlap')
+    run(f'python -m meeteval.der dscore -h hyp.rttm -r ref.rttm --regex ".*A"')
+    run(f'python -m meeteval.der dscore -h hyp.seglst.json -r ref.seglst.json')
 
 def test_burn_merge():
     run(f'python -m meeteval.wer cpwer -h hypA.stm -r refA.stm')  # create hypA_cpwer_per_reco.json and hypA_cpwer.json


### PR DESCRIPTION
In #97 it was mentioned, that `dscore` calculates the `DER` differently to `md-eval-22.pl`, if no uem file is given:
 - `md-eval-22.pl`: Choose the scoring region, such that it starts with the first reference and ends with the last reference.
 - `dscore`:  Score everything. Implementation: Create an uem with the scoring regions to be the smallest start in ref and hyp and the end is the last time in ref and hyp.

Additional bugfix:
 - `md-eval-22.pl` ignores the uem files, if the filenames/session_ids contain dots
 - `dscore` fails with a lengthy error

ToDO:
 - [x] Disable the dscore code and use only md_eval to mirror what dscore does. The dscore code doesn't work with numpy 2