### PR TITLE
Add meeteval-wer normalize CLI command

### DIFF
--- a/meeteval/wer/__main__.py
+++ b/meeteval/wer/__main__.py
@@ -467,6 +467,17 @@ def average(files, out='-', regex=None):
     return _merge(files, out, average=True, regex=regex)
 
 
+def normalize(
+        file,
+        out,
+        normalizer,
+):
+    """
+    Normalize the words in the transcript with the normalizer `normalizer`.
+    """
+    from meeteval.wer.api import normalize
+    meeteval.io.dump(normalize(file, normalizer=normalizer), out)
+
 class SmartFormatter(argparse.ArgumentDefaultsHelpFormatter):
     """
     https://stackoverflow.com/a/22157136/5766934
@@ -669,7 +680,7 @@ class CLI:
                 nargs='+', action=self.extend_action,
             )
         elif name == 'normalizer':
-            from meeteval.wer.api import normalizers
+            from meeteval.wer.normalizer import normalizers
             command_parser.add_argument(
                 '--normalizer',
                 help=textwrap.dedent(normalizers.__doc__),
@@ -684,6 +695,8 @@ class CLI:
             )
         elif name == 'files':
             command_parser.add_argument('files', nargs='+')
+        elif name == 'file':
+            command_parser.add_argument('file')
         else:
             raise AssertionError("Error in command definition", name)
 
@@ -762,6 +775,7 @@ def cli():
     cli.add_command(greedy_tcorcwer)
     cli.add_command(merge)
     cli.add_command(average)
+    cli.add_command(normalize)
 
     cli.run()
 

--- a/meeteval/wer/__main__.py
+++ b/meeteval/wer/__main__.py
@@ -470,7 +470,7 @@ def average(files, out='-', regex=None):
 def normalize(
         file,
         out,
-        normalizer='chime8',
+        normalizer='lower,rm(.?!,)',
 ):
     """
     Normalize the words in the transcript with the normalizer `normalizer`.

--- a/meeteval/wer/__main__.py
+++ b/meeteval/wer/__main__.py
@@ -470,7 +470,7 @@ def average(files, out='-', regex=None):
 def normalize(
         file,
         out,
-        normalizer,
+        normalizer='chime8',
 ):
     """
     Normalize the words in the transcript with the normalizer `normalizer`.

--- a/meeteval/wer/api.py
+++ b/meeteval/wer/api.py
@@ -41,87 +41,6 @@ def _maybe_load(paths, file_format) -> meeteval.io.SegLST:
             raise TypeError(type(paths), paths) from e
 
 
-class _Normalizers:
-    """
-    A normalizer that is applied to the transcript.
-    Choices:
-    - None: Do nothing (default)
-    - lower,rm(.?!,): Lowercase the transcript and remove punctuations (.,?!).
-    - lower,rm([^a-z0-9 ]): Lowercase the transcript and remove all characters that are not a-z, 0-9, or space.
-    - chime6: Normalize the transcript according to the CHiME-6 challenge.
-    - chime7: Normalize the transcript according to the CHiME-7 challenge.
-              In contrast to chime6, words like "hmm" are normalized,
-              e.g. "hm", "hmm" and "hmmm" get "hmmm".
-    - chime8: Normalize the transcript according to the CHiME-8 challenge.
-              Removes words like "hmm", converts integers to words,
-              and much more.
-    """
-    # Note: The text above is used as CLI help text.
-    #       So the None is not a real option for this class, but the default
-    #       value for the normalizer argument.
-
-    def keys(self):
-        return [
-            'lower,rm(.?!,)',
-            'lower,rm([^a-z0-9 ])',
-            'chime6',
-            'chime7',
-            'chime8',
-        ]
-
-    def __getitem__(self, normalizer):
-        """
-        >>> def test(normalizer):
-        ...     seg = {'words': 'Hello, World! äèア😊 hm hmm hmmm [noise] [inaudible] wi-fi word-word 1.1 11 Mr. then,\" said'}
-        ...     return _Normalizers()[normalizer](seg)['words']
-        >>> test('lower,rm(.?!,)')
-        'hello world äèア😊 hm hmm hmmm [noise] [inaudible] wi-fi word-word 11 11 mr then" said'
-        >>> test('lower,rm([^a-z0-9 ])')
-        'hello world hm hmm hmmm noise inaudible wifi wordword 11 11 mr then said'
-        >>> test('chime8')
-        'hello world aeア wifi word word 1.1 eleven mister then said'
-        >>> test('chime7')
-        'hello world äèア😊 hmmm hmmm hmmm wi-fi word-word 11 11 mr then said'
-        >>> test('chime6')
-        'hello world äèア😊 hm hmm hmmm wi-fi word-word 11 11 mr then said'
-        """
-        if normalizer == 'lower,rm(.?!,)':
-            def normalizer(seg):
-                seg['words'] = seg['words'].lower().replace('.', '').replace('?', '').replace('!', '').replace(',', '')
-                return seg
-        elif normalizer == 'lower,rm([^a-z0-9 ])':
-            r = re.compile('[^a-z0-9 ]')
-            r2 = re.compile(r'\s{2,}')
-            def normalizer(seg):
-                seg['words'] = r2.sub(' ', r.sub('', seg['words'].lower()).strip())
-                return seg
-        elif normalizer in ['chime8', 'chime7', 'chime6']:
-            from chime_utils.text_norm import get_txt_norm  # pip install git+https://github.com/chimechallenge/chime-utils
-            chime_utils_normalizer = get_txt_norm(normalizer)
-
-            # Note:
-            #     chime6 and chime7 remove all words, when [redacted] is
-            #     present.
-
-            def normalizer(seg):
-                words = chime_utils_normalizer(seg['words'])
-                if words != chime_utils_normalizer(seg['words']):
-                    raise RuntimeError(
-                        f'You discovered an idempotence bug in the chime_utils normalizer: {normalizer!r}.\n'
-                        f'Original:         {seg["words"]}\n'
-                        f'Normalized:       {words}\n'
-                        f'Normalized again: {chime_utils_normalizer(words)}'
-                    )
-                seg['words'] = words
-                return seg
-        else:
-            raise ValueError(f'Unknown normalizer: {normalizer}. Available normalizers: {self.keys()}')
-        return normalizer
-
-
-normalizers = _Normalizers()
-
-
 def _load_texts(
         reference_paths: 'list[str]',
         hypothesis_paths: 'list[str]',
@@ -172,9 +91,9 @@ def _load_texts(
         hypothesis = hypothesis.filter_by_uem(uem)
 
     if normalizer is not None:
-        normalizer = normalizers[normalizer]
-        reference = reference.map(normalizer)
-        hypothesis = hypothesis.map(normalizer)
+        from meeteval.wer.normalizer import normalize
+        reference = normalize(reference, normalizer=normalizer)
+        hypothesis = normalize(hypothesis, normalizer=normalizer)
 
     return reference, hypothesis
 

--- a/meeteval/wer/api.py
+++ b/meeteval/wer/api.py
@@ -383,7 +383,7 @@ def greedy_tcorcwer(
     return results
 
 
-def normalize(input, normalizer):
+def normalize(input, normalizer='chime8'):
     """
     Normalizes input and returns the result.
     """

--- a/meeteval/wer/api.py
+++ b/meeteval/wer/api.py
@@ -381,3 +381,14 @@ def greedy_tcorcwer(
     if average.reference_self_overlap is not None:
         average.reference_self_overlap.warn('reference')
     return results
+
+
+def normalize(input, normalizer):
+    """
+    Normalizes input and returns the result.
+    """
+    from meeteval.wer.normalizer import normalize
+    if isinstance(input, (str, Path)):
+        input = meeteval.io.load(input)
+    normalized = normalize(input, normalizer=normalizer)
+    return normalized

--- a/meeteval/wer/api.py
+++ b/meeteval/wer/api.py
@@ -383,7 +383,7 @@ def greedy_tcorcwer(
     return results
 
 
-def normalize(input, normalizer='chime8'):
+def normalize(input, normalizer='lower,rm(.?!,)'):
     """
     Normalizes input and returns the result.
     """

--- a/meeteval/wer/normalizer.py
+++ b/meeteval/wer/normalizer.py
@@ -114,7 +114,7 @@ def normalize(input, *, normalizer: str):
     ...     normalizer='chime8'
     ... ).dumps())
     recordingA 1 Alice 1 1 hello world aeア wifi word word 1.1 eleven mister then said
-
+    <BLANKLINE>
     """
     if normalizer is None:
         return input

--- a/meeteval/wer/normalizer.py
+++ b/meeteval/wer/normalizer.py
@@ -1,0 +1,123 @@
+
+from meeteval.io.seglst import seglst_map
+import re
+import meeteval
+
+__all__ = [
+    'normalize',
+]
+
+
+class _Normalizers:
+    """
+    A normalizer that is applied to the transcript.
+    Choices:
+    - None: Do nothing (default)
+    - lower,rm(.?!,): Lowercase the transcript and remove punctuations (.,?!).
+    - lower,rm([^a-z0-9 ]): Lowercase the transcript and remove all characters that are not a-z, 0-9, or space.
+    - chime6: Normalize the transcript according to the CHiME-6 challenge.
+    - chime7: Normalize the transcript according to the CHiME-7 challenge.
+              In contrast to chime6, words like "hmm" are normalized,
+              e.g. "hm", "hmm" and "hmmm" get "hmmm".
+    - chime8: Normalize the transcript according to the CHiME-8 challenge.
+              Removes words like "hmm", converts integers to words,
+              and much more.
+    """
+    # Note: The text above is used as CLI help text.
+    #       So the None is not a real option for this class, but the default
+    #       value for the normalizer argument.
+
+    def keys(self):
+        return [
+            'lower,rm(.?!,)',
+            'lower,rm([^a-z0-9 ])',
+            'chime6',
+            'chime7',
+            'chime8',
+        ]
+
+    def __getitem__(self, normalizer):
+        """
+        >>> def test(normalizer):
+        ...     seg = {'words': 'Hello, World! äèア😊 hm hmm hmmm [noise] [inaudible] wi-fi word-word 1.1 11 Mr. then,\" said'}
+        ...     return _Normalizers()[normalizer](seg)['words']
+        >>> test('lower,rm(.?!,)')
+        'hello world äèア😊 hm hmm hmmm [noise] [inaudible] wi-fi word-word 11 11 mr then" said'
+        >>> test('lower,rm([^a-z0-9 ])')
+        'hello world hm hmm hmmm noise inaudible wifi wordword 11 11 mr then said'
+        >>> test('chime8')
+        'hello world aeア wifi word word 1.1 eleven mister then said'
+        >>> test('chime7')
+        'hello world äèア😊 hmmm hmmm hmmm wi-fi word-word 11 11 mr then said'
+        >>> test('chime6')
+        'hello world äèア😊 hm hmm hmmm wi-fi word-word 11 11 mr then said'
+        """
+        if normalizer == 'lower,rm(.?!,)':
+            def normalizer(seg):
+                seg['words'] = seg['words'].lower().replace('.', '').replace('?', '').replace('!', '').replace(',', '')
+                return seg
+        elif normalizer == 'lower,rm([^a-z0-9 ])':
+            r = re.compile('[^a-z0-9 ]')
+            r2 = re.compile(r'\s{2,}')
+            def normalizer(seg):
+                seg['words'] = r2.sub(' ', r.sub('', seg['words'].lower()).strip())
+                return seg
+        elif normalizer in ['chime8', 'chime7', 'chime6']:
+            from chime_utils.text_norm import get_txt_norm  # pip install git+https://github.com/chimechallenge/chime-utils
+            chime_utils_normalizer = get_txt_norm(normalizer)
+
+            # Note:
+            #     chime6 and chime7 remove all words, when [redacted] is
+            #     present.
+
+            def normalizer(seg):
+                words = chime_utils_normalizer(seg['words'])
+                if words != chime_utils_normalizer(seg['words']):
+                    raise RuntimeError(
+                        f'You discovered an idempotence bug in the chime_utils normalizer: {normalizer!r}.\n'
+                        f'Original:         {seg["words"]}\n'
+                        f'Normalized:       {words}\n'
+                        f'Normalized again: {chime_utils_normalizer(words)}'
+                    )
+                seg['words'] = words
+                return seg
+        else:
+            raise ValueError(f'Unknown normalizer: {normalizer}. Available normalizers: {self.keys()}')
+        return normalizer
+
+
+normalizers = _Normalizers()
+
+
+@seglst_map(required_keys=('words',))
+def normalize(input, *, normalizer: str):
+    """
+    Normalize the words in the transcript with the normalizer `normalizer`.
+    Works with any object convertible to SegLST.
+
+    Available normalizers are:
+    - None: Do nothing (default)
+    - lower,rm(.?!,): Lowercase the transcript and remove punctuations (.,?!).
+    - lower,rm([^a-z0-9 ]): Lowercase the transcript and remove all characters that are not a-z, 0-9, or space.
+    - chime6: Normalize the transcript according to the CHiME-6 challenge.
+    - chime7: Normalize the transcript according to the CHiME-7 challenge.
+              In contrast to chime6, words like "hmm" are normalized,
+              e.g. "hm", "hmm" and "hmmm" get "hmmm".
+    - chime8: Normalize the transcript according to the CHiME-8 challenge.
+              Removes words like "hmm", converts integers to words,
+              and much more.
+
+    >>> normalize(meeteval.io.SegLST([{'words': 'Hello, World!'}]), normalizer='lower,rm(.?!,)')
+    SegLST(segments=[{'words': 'hello world'}])
+    >>> print(normalize(
+    ...     meeteval.io.STM.parse('''recordingA 1 Alice 1 1 hello world äèア😊 hm hmm hmmm [noise] [inaudible] wi-fi word-word 1.1 11 mr then" said'''), 
+    ...     normalizer='chime8'
+    ... ).dumps())
+    recordingA 1 Alice 1 1 hello world aeア wifi word word 1.1 eleven mister then said
+
+    """
+    if normalizer is None:
+        return input
+    if isinstance(normalizer, str):
+        normalizer = normalizers[normalizer]
+    return input.map(normalizer)


### PR DESCRIPTION
Adds a command `meeteval-wer normalize` that normalizes the words in any input file according to one normalizer and dumps it in the same or any other format.

```console
$ meeteval-wer normalize example_files/ref.stm --normalizer 'chime8' -o -
recordingA 1 Alice 1 1 effort made was a lot i know you are busy we need to make the new version clean
recordingA 1 Bob 1 2 strategic staircase we need a paradigm shift
recordingA 1 Bob 2 3
recordingA 1 Alice 2 3 pipeline bob called an all hands this afternoon
recordingB 1 Alice 3 4 hop on the bandwagon let us schedule a standup during the sprint to review our kpis
recordingB 1 Alice 4 5 hop on the bandwagon let us schedule a standup during the sprint to review our kpis
recordingA 1 Alice 5 6 organic growth what do you feel you would bring to the table if you were hired for this position it just needs more cowbell yet groom the backlog land the plane
```

The default is set to `chime8`. I'm not sure if this is the best choice for the default. I may make the `--normalizer` option mandatory.