### PR TITLE
Add SISO WER to high-level Python api

### DIFF
--- a/example_files/hyp_siso.stm
+++ b/example_files/hyp_siso.stm
@@ -1,0 +1,4 @@
+recordingA 1 Alice 0 1 Effort made was a lot i know your busy we need two make the new version clean
+recordingA 1 Bob 1 2.5 Strategic staircase we need a paradigm shift
+recordingC 1 Bob 2.1 3 Pipeline Bob called an all-hands this afternoon
+

--- a/example_files/ref_siso.stm
+++ b/example_files/ref_siso.stm
@@ -1,0 +1,3 @@
+recordingA 1 Alice 1 1 Effort made was a lot i know you're busy we need to make the new version clean
+recordingA 1 Bob 1 2 Strategic staircase we need a paradigm shift
+recordingC 1 Bob 2.1 3 Pipeline Bob called an all-hands this afternoon

--- a/meeteval/wer/__main__.py
+++ b/meeteval/wer/__main__.py
@@ -153,6 +153,7 @@ def sisower(
         reference, hypothesis,
         regex=None,
         normalizer=None,
+        partial=False,
         average_out='{parent}/{stem}_wer.json',
         per_reco_out='{parent}/{stem}_wer_per_reco.json',
 ):
@@ -164,6 +165,7 @@ def sisower(
     results = meeteval.wer.sisower(
         reference, hypothesis,
         regex=regex,
+        partial=partial,
         normalizer=normalizer,
     )
     _save_results(results, hypothesis, per_reco_out, average_out, wer_name='SISO-WER')

--- a/meeteval/wer/__main__.py
+++ b/meeteval/wer/__main__.py
@@ -141,7 +141,7 @@ def _save_results(
     return average
 
 
-def wer(
+def sisower(
         reference, hypothesis,
         regex=None,
         normalizer=None,
@@ -149,7 +149,7 @@ def wer(
         per_reco_out='{parent}/{stem}_wer_per_reco.json',
 ):
     """Computes the "standard" WER (SISO WER). Only support kaldi-style text files"""
-    results = meeteval.wer.wer(
+    results = meeteval.wer.sisower(
         reference, hypothesis,
         regex=regex,
         normalizer=normalizer,
@@ -752,7 +752,7 @@ class CLI:
 def cli():
     cli = CLI()
 
-    cli.add_command(wer)
+    cli.add_command(sisower, 'wer')
     cli.add_command(cpwer)
     cli.add_command(orcwer)
     cli.add_command(greedy_orcwer)

--- a/meeteval/wer/__main__.py
+++ b/meeteval/wer/__main__.py
@@ -756,7 +756,8 @@ class CLI:
 def cli():
     cli = CLI()
 
-    cli.add_command(sisower, 'wer')
+    cli.add_command(sisower)
+    cli.add_command(sisower, 'wer') # Alias for backwards compatibility
     cli.add_command(cpwer)
     cli.add_command(orcwer)
     cli.add_command(greedy_orcwer)

--- a/meeteval/wer/__main__.py
+++ b/meeteval/wer/__main__.py
@@ -109,9 +109,17 @@ def _save_results(
     """
     parent, stem = _get_parent_stem(hypothesis_paths)
 
+    def to_str(example_id):
+        if isinstance(example_id, str):
+            return example_id
+        elif isinstance(example_id, tuple):
+            return '___'.join(example_id)
+        else:
+            raise TypeError(type(example_id), example_id)
+        
     # Save details
     _dump({
-        example_id: dataclasses.asdict(error_rate)
+        to_str(example_id): dataclasses.asdict(error_rate)
         for example_id, error_rate in per_reco.items()
     }, per_reco_out.format(parent=parent, stem=stem))
 

--- a/meeteval/wer/__main__.py
+++ b/meeteval/wer/__main__.py
@@ -143,28 +143,18 @@ def _save_results(
 
 def wer(
         reference, hypothesis,
+        regex=None,
+        normalizer=None,
         average_out='{parent}/{stem}_wer.json',
         per_reco_out='{parent}/{stem}_wer_per_reco.json',
 ):
     """Computes the "standard" WER (SISO WER). Only support kaldi-style text files"""
-    reference_paths = [Path(r) for r in reference]
-    hypothesis_paths = [Path(h) for h in hypothesis]
-    if (
-            any(r.suffix != '' for r in reference_paths) or
-            any(h.suffix != '' for h in hypothesis_paths)
-    ):
-        raise ValueError(
-            f'Only (kaldi-style) text files are supported, i.e., files without '
-            f'an extension (not dot allowed in the file name).\n'
-            f'Got: {reference_paths} for reference and {hypothesis_paths} for '
-            f'hypothesis.'
-        )
-    from meeteval.io.keyed_text import KeyedText
-    reference = KeyedText.load(reference)
-    hypothesis = KeyedText.load(hypothesis)
-    from meeteval.wer.wer.siso import siso_word_error_rate_multifile
-    results = siso_word_error_rate_multifile(reference, hypothesis)
-    _save_results(results, hypothesis_paths, per_reco_out, average_out, wer_name='WER')
+    results = meeteval.wer.wer(
+        reference, hypothesis,
+        regex=regex,
+        normalizer=normalizer,
+    )
+    _save_results(results, hypothesis, per_reco_out, average_out, wer_name='SISO-WER')
 
 
 def orcwer(

--- a/meeteval/wer/__main__.py
+++ b/meeteval/wer/__main__.py
@@ -148,7 +148,11 @@ def sisower(
         average_out='{parent}/{stem}_wer.json',
         per_reco_out='{parent}/{stem}_wer_per_reco.json',
 ):
-    """Computes the "standard" WER (SISO WER). Only support kaldi-style text files"""
+    """Computes the "standard" WER (SISO WER).
+    
+    Filenames / session_ids must be unique and there must be exactly one 
+    hypothesis per reference.
+    """
     results = meeteval.wer.sisower(
         reference, hypothesis,
         regex=regex,

--- a/meeteval/wer/api.py
+++ b/meeteval/wer/api.py
@@ -7,7 +7,7 @@ import meeteval.io
 from meeteval.wer.wer import ErrorRate
 
 __all__ = [
-    'wer',
+    'sisower',
     'cpwer',
     'orcwer',
     'greedy_orcwer',
@@ -99,7 +99,7 @@ def _load_texts(
     return reference, hypothesis
 
 
-def wer(
+def sisower(
     reference, hypothesis,
     regex=None,
     normalizer=None,

--- a/meeteval/wer/api.py
+++ b/meeteval/wer/api.py
@@ -7,6 +7,7 @@ import meeteval.io
 from meeteval.wer.wer import ErrorRate
 
 __all__ = [
+    'wer',
     'cpwer',
     'orcwer',
     'greedy_orcwer',
@@ -96,6 +97,21 @@ def _load_texts(
         hypothesis = normalize(hypothesis, normalizer=normalizer)
 
     return reference, hypothesis
+
+
+def wer(
+    reference, hypothesis,
+    regex=None,
+    normalizer=None,
+):
+    """Computes the (standard) Word Error Rate (WER)"""
+    from meeteval.wer.wer import siso_word_error_rate_multifile
+    reference, hypothesis = _load_texts(
+        reference, hypothesis, regex=regex,
+        normalizer=normalizer,
+    )
+    results = siso_word_error_rate_multifile(reference, hypothesis)
+    return results
 
 
 def orcwer(

--- a/meeteval/wer/api.py
+++ b/meeteval/wer/api.py
@@ -103,6 +103,7 @@ def sisower(
     reference, hypothesis,
     regex=None,
     normalizer=None,
+    partial=False,
 ):
     """Computes the (standard) Word Error Rate (WER)"""
     from meeteval.wer.wer import siso_word_error_rate_multifile
@@ -110,7 +111,7 @@ def sisower(
         reference, hypothesis, regex=regex,
         normalizer=normalizer,
     )
-    results = siso_word_error_rate_multifile(reference, hypothesis)
+    results = siso_word_error_rate_multifile(reference, hypothesis, partial=partial)
     return results
 
 

--- a/meeteval/wer/wer/siso.py
+++ b/meeteval/wer/wer/siso.py
@@ -129,6 +129,7 @@ def siso_word_error_rate(reference: 'SegLST', hypothesis: 'SegLST') -> ErrorRate
 def siso_word_error_rate_multifile(
         reference,
         hypothesis,
+        partial=False,
 ) -> 'dict[str, ErrorRate]':
     """
     Computes the standard WER for each example in the reference and hypothesis
@@ -167,6 +168,7 @@ def siso_word_error_rate_multifile(
     return apply_multi_file(
         siso_word_error_rate, reference, hypothesis,
         allowed_empty_examples_ratio=0,
+        partial=partial,
         _groupby=groupby,
     )
 

--- a/meeteval/wer/wer/siso.py
+++ b/meeteval/wer/wer/siso.py
@@ -141,6 +141,12 @@ def siso_word_error_rate_multifile(
     from meeteval.io.seglst import apply_multi_file
 
     def groupby(r, h):
+        """
+        Checks whether the session IDs or (session ID, speaker) tuples are 
+        unique in the reference and hypothesis and then groups by the 
+        respective keys. `apply_multi_file` will then check whether the grouped
+        keys match between reference and hypothesis.
+        """
         if (
             len(r.unique('session_id')) == len(r)
             and len(h.unique('session_id')) == len(h)

--- a/meeteval/wer/wer/siso.py
+++ b/meeteval/wer/wer/siso.py
@@ -128,7 +128,7 @@ def siso_word_error_rate(reference: 'SegLST', hypothesis: 'SegLST') -> ErrorRate
 
 def siso_word_error_rate_multifile(
         reference,
-        hypothesis
+        hypothesis,
 ) -> 'dict[str, ErrorRate]':
     """
     Computes the standard WER for each example in the reference and hypothesis
@@ -138,9 +138,36 @@ def siso_word_error_rate_multifile(
     `sum(siso_word_error_rate_multifile(r, h).values())`.
     """
     from meeteval.io.seglst import apply_multi_file
+
+    def groupby(r, h):
+        if (
+            len(r.unique('session_id')) == len(r)
+            and len(h.unique('session_id')) == len(h)
+        ):
+            return r.groupby('session_id'), h.groupby('session_id')
+        
+        if 'speaker' not in r.T.keys() or 'speaker' not in h.T.keys():
+            raise ValueError(
+                f'The filenames / session ids are not unique and speaker IDs '
+                f'are not present. The SISO-WER needs unique session IDs or '
+                f'(session ID, speaker) pairs. '
+            )
+        
+        if (
+            len(r.unique(('session_id', 'speaker'))) == len(r)
+            and len(h.unique(('session_id', 'speaker'))) == len(h)
+        ):
+            return r.groupby(('session_id', 'speaker')), h.groupby(('session_id', 'speaker'))
+    
+        raise ValueError(
+            f'(session ID, speaker) pairs are not unique. The SISO-WER needs '
+            f'unique session IDs or (session ID, speaker) pairs. '
+        )
+
     return apply_multi_file(
         siso_word_error_rate, reference, hypothesis,
-        allowed_empty_examples_ratio=0
+        allowed_empty_examples_ratio=0,
+        _groupby=groupby,
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -202,6 +202,9 @@ def test_burn_average():
 
 def test_burn_siso():
     run(f'python -m meeteval.wer wer -h text_hyp -r text_ref')
+    run(f'python -m meeteval.wer sisower -h text_hyp -r text_ref')
+    run(f'python -m meeteval.wer wer -h hyp_siso.stm -r ref_siso.stm')
+    run(f'python -m meeteval.wer wer -h text_hyp -r text_ref --normalizer "lower,rm(.?!,)"')
 
 
 def test_viz_html():


### PR DESCRIPTION
Closes #110.

Add the SISO WER as `meeteval.wer.sisower` to the high-level Python api.

I named it `sisower` instead of `wer` to avoid conflicts with the module `meeteval.wer.wer`. I didn't change the CLI command name, it is still just `wer`.

The new API function now also supports STM and SegLST files when the file names are unique. Previously, only keyed text files were supported. This was done to avoid accidentally calling the SISO WER when you wanted to compute, e.g., the cpwer. But I now think that it is very unlikely to have unique filenames / session_ids when you don't want to compute the SISO WER.