### PR TITLE
Fix that the alignment calculation for the visualization didn't use point estimates

### DIFF
--- a/meeteval/viz/visualize.py
+++ b/meeteval/viz/visualize.py
@@ -436,7 +436,7 @@ def get_visualization_data(ref: SegLST, hyp: SegLST, assignment='tcp', alignment
 
     data['info']['wer_by_speakers'] = {
         speaker: wer_by_speaker(speaker)
-        for speaker in list(ref.unique('speaker'))
+        for speaker in list((ref + hyp).unique('speaker'))
     }
     for k in [
         'errors', 'length', 'insertions', 'deletions', 'substitutions'

--- a/meeteval/viz/visualize.py
+++ b/meeteval/viz/visualize.py
@@ -134,8 +134,8 @@ def get_alignment(data, alignment_type, collar=5):
         raise NotImplementedError(alignment_type)
 
     # Compute alignment and extract words
-    ref = ref.sorted('start_time').groupby('speaker')
-    hyp = hyp.sorted('start_time').groupby('speaker')
+    ref = ref.groupby('speaker')
+    hyp = hyp.groupby('speaker')
 
     for k in set(ref.keys()) | set(hyp.keys()):
         a = align(

--- a/meeteval/viz/visualize.py
+++ b/meeteval/viz/visualize.py
@@ -136,7 +136,16 @@ def get_alignment(data, alignment_type, collar=5):
     hyp = hyp.sorted('start_time').groupby('speaker')
 
     for k in set(ref.keys()) | set(hyp.keys()):
-        a = align(ref.get(k, SegLST([])), hyp.get(k, SegLST([])))
+        a = align(
+            ref.get(k, SegLST([])),
+            hyp.get(k, SegLST([])).map(
+                lambda s: {
+                    **s,
+                    'start_time': (s['end_time'] + s['start_time']) / 2,
+                    'end_time': (s['end_time'] + s['start_time']) / 2,
+                }
+            )
+        )
 
         # Add a list of matches to each word. This assumes that `align` keeps the
         # identity of the segments

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -77,3 +77,42 @@ def test_viz_precompute_wer(alignment):
         text = (example_files / f'viz/test-{k}-{alignment}.html').read_text()
         text = re.sub(r'viz-[0-9a-f\-]*', '#viz-XXXX', text)
         assert text == precomputed_text
+
+
+@pytest.mark.parametrize(
+    'alignment',
+    [
+        'cp', 'tcp', 'orc', 'tcorc', 'greedy_tcorc',
+        'greedy_orc', 'greedy_dicp', 'greedy_ditcp'
+    ]
+)
+def test_viz_speaker_mismatch(alignment):
+    """
+    Tests if the code that generated the visualization produces an html file.
+    Does not test if the visualization is correct.
+    """
+    ref1 = meeteval.io.asseglst(meeteval.io.STM.parse(
+        'rec1 0 spk1 10 20 Hello World\n'
+    ))
+    ref2 = meeteval.io.asseglst(meeteval.io.STM.parse(
+        'rec1 0 spk1 10 20 Hello World\n'
+        'rec1 0 spk2 20 30 Goodbye World\n'
+    ))
+    hyp1 = meeteval.io.asseglst(meeteval.io.STM.parse(
+        'rec1 0 spk1 10 20 Hello World\n'
+    ))
+    hyp2 = meeteval.io.asseglst(meeteval.io.STM.parse(
+        'rec1 0 spk1 10 20 Hello World\n'
+        'rec1 0 spk2 20 30 Goodbye World\n'
+    ))
+
+    for i, (ref, hyp) in enumerate([
+        (ref1, hyp2),
+        (ref2, hyp1)
+    ]):
+        meeteval.viz.AlignmentVisualization(
+            ref,
+            hyp,
+            alignment=alignment,
+        ).dump(example_files / f'viz/test-mismatch-{i}-{alignment}.html')
+        assert (example_files / f'viz/test-mismatch-{i}-{alignment}.html').exists()


### PR DESCRIPTION
Fix the mismatch between shown WER and alignment for corner cases of time constraint visualization.

The shown WER uses the point estimates for hyp (same as cli default), but the alignment calculation didn't use the point estimates.

This has only an effect for time constraint WERs and is only noticeable, when the time unit in the input files is not second,
e.g., a collar of 5 samples is far to low, while a collar of 5 seconds is a good choice, where the issue is barely noticeable.

How can this be observed:
![image](https://github.com/user-attachments/assets/c5206602-fbb5-4637-88a2-897b24f7065b)
In the tooltip to the WER, the count column is correct for the WER, but the speaker statistics reflect the alignment.
When there is a mismatch, it indicates, that some correct/substitution assignments are at the edge of the collar.

Should we add an assert to the code, that the statistics match? I don't know, if the same sub/ins/del is reported, since they are not unique.

@tobvogel Thanks for the report.