### PR TITLE
Clear root element before building interface

### DIFF
--- a/meeteval/viz/visualize.js
+++ b/meeteval/viz/visualize.js
@@ -666,6 +666,13 @@ function alignment_visualization(
 
     let root_element = d3.select(element_id);
 
+    /* Clear the HTML element.
+     * Use-case: Somebody downloads the a page from the browser for later offline
+     * use. The downloaded HTML contains a rendered version of the visualization
+     * and a second one will be appended when the element is not deleted
+     */
+    root_element.html(null);
+
     /* Mouse drag */
     let dragActive = false; // We can only have one drag at a time globally
 

--- a/meeteval/viz/visualize.py
+++ b/meeteval/viz/visualize.py
@@ -709,7 +709,7 @@ class AlignmentVisualization:
             {d3}
             {font_awesome}
             {css}
-            <div class="meeteval-viz" id='{element_id}'><div>
+            <div class="meeteval-viz" id='{element_id}'></div>
             {visualize_js}
             <script>
 


### PR DESCRIPTION
This fixes an issue, where the interface breaks when the user downlaods the webpage from a webbrowser. The saved HTML then contains a rendered version of the interface and the JS code appends a second one. Now, the container is cleared before the interface is re-drawn.